### PR TITLE
[003-trip] 여행 기록장을 만들고 수정하는 기능

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,7 @@ dependencies {
     annotationProcessor 'com.querydsl:querydsl-apt:5.0.0:jakarta'
     annotationProcessor 'jakarta.annotation:jakarta.annotation-api'
     annotationProcessor 'jakarta.persistence:jakarta.persistence-api'
+    implementation 'org.springframework.data:spring-data-elasticsearch:4.2.2'
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'

--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,8 @@ dependencies {
     annotationProcessor 'jakarta.annotation:jakarta.annotation-api'
     annotationProcessor 'jakarta.persistence:jakarta.persistence-api'
     implementation 'org.springframework.data:spring-data-elasticsearch:4.2.2'
+    testImplementation 'org.mockito:mockito-inline'
+
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'

--- a/build.gradle
+++ b/build.gradle
@@ -8,11 +8,6 @@ group = 'com.trip'
 version = '0.0.1-SNAPSHOT'
 sourceCompatibility = '17'
 
-configurations {
-    compileOnly {
-        extendsFrom annotationProcessor
-    }
-}
 
 repositories {
     mavenCentral()
@@ -30,6 +25,10 @@ dependencies {
     runtimeOnly 'com.mysql:mysql-connector-j'
     annotationProcessor 'org.projectlombok:lombok'
     implementation 'io.jsonwebtoken:jjwt:0.9.1'
+    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+    annotationProcessor 'com.querydsl:querydsl-apt:5.0.0:jakarta'
+    annotationProcessor 'jakarta.annotation:jakarta.annotation-api'
+    annotationProcessor 'jakarta.persistence:jakarta.persistence-api'
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
@@ -37,4 +36,18 @@ dependencies {
 
 tasks.named('test') {
     useJUnitPlatform()
+}
+
+def querydslDir = "$buildDir/generated"
+
+sourceSets {
+    main.java.srcDirs += [ querydslDir ]
+}
+
+tasks.withType(JavaCompile) {
+    options.annotationProcessorGeneratedSourcesDirectory = file(querydslDir)
+}
+
+clean.doLast {
+    file(querydslDir).deleteDir()
 }

--- a/src/main/java/com/trip/diary/config/AsyncConfig.java
+++ b/src/main/java/com/trip/diary/config/AsyncConfig.java
@@ -1,0 +1,23 @@
+package com.trip.diary.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+import java.util.concurrent.Executor;
+
+@EnableAsync
+@Configuration
+public class AsyncConfig {
+    @Bean
+    public Executor executor(){
+        int processorSize = Runtime.getRuntime().availableProcessors();
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(processorSize);
+        executor.setMaxPoolSize(processorSize * 2);
+        executor.setQueueCapacity(processorSize * 6);
+        executor.initialize();
+        return executor;
+    }
+}

--- a/src/main/java/com/trip/diary/config/ElasticSearchConfig.java
+++ b/src/main/java/com/trip/diary/config/ElasticSearchConfig.java
@@ -1,0 +1,25 @@
+package com.trip.diary.config;
+
+import org.elasticsearch.client.RestHighLevelClient;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.elasticsearch.client.ClientConfiguration;
+import org.springframework.data.elasticsearch.client.RestClients;
+import org.springframework.data.elasticsearch.config.AbstractElasticsearchConfiguration;
+import org.springframework.data.elasticsearch.repository.config.EnableElasticsearchRepositories;
+
+@Configuration
+@EnableElasticsearchRepositories
+public class ElasticSearchConfig extends AbstractElasticsearchConfiguration {
+
+    @Value("${spring.data.elasticsearch.url}")
+    String url;
+
+    @Override
+    public RestHighLevelClient elasticsearchClient() {
+        ClientConfiguration clientConfiguration = ClientConfiguration.builder()
+                .connectedTo(url)
+                .build();
+        return RestClients.create(clientConfiguration).rest();
+    }
+}

--- a/src/main/java/com/trip/diary/controller/TripController.java
+++ b/src/main/java/com/trip/diary/controller/TripController.java
@@ -1,0 +1,47 @@
+package com.trip.diary.controller;
+
+import com.trip.diary.dto.*;
+import com.trip.diary.security.MemberPrincipal;
+import com.trip.diary.service.TripService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Slice;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@Slf4j
+@RequiredArgsConstructor
+@RequestMapping("/trips")
+public class TripController {
+
+    private final TripService tripService;
+
+    @PostMapping
+    private ResponseEntity<CreateTripDto> createTrip(@Valid @RequestBody CreateTripForm form,
+                                                     @AuthenticationPrincipal MemberPrincipal principal) {
+        return ResponseEntity.ok(tripService.create(form, principal.getMember()));
+    }
+
+    @PutMapping("/{tripId}")
+    private ResponseEntity<TripDto> updateTrip(@PathVariable Long tripId,
+                                               @Valid @RequestBody UpdateTripForm form,
+                                               @AuthenticationPrincipal MemberPrincipal principal) {
+        return ResponseEntity.ok(tripService.updateTrip(tripId, form, principal.getMember()));
+    }
+
+    @GetMapping("/members")
+    private ResponseEntity<Slice<MemberDto>> getAddableMembers(@AuthenticationPrincipal MemberPrincipal principal) {
+        return ResponseEntity.ok(tripService.getAddableMembers(principal.getMember()));
+    }
+
+    @GetMapping("/{tripId}/participants")
+    private ResponseEntity<List<ParticipantDto>> getTripParticipants(@PathVariable Long tripId,
+                                                                     @AuthenticationPrincipal MemberPrincipal principal) {
+        return ResponseEntity.ok(tripService.getTripParticipants(tripId, principal.getMember()));
+    }
+}

--- a/src/main/java/com/trip/diary/controller/TripController.java
+++ b/src/main/java/com/trip/diary/controller/TripController.java
@@ -6,7 +6,6 @@ import com.trip.diary.service.TripService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.domain.Slice;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -32,11 +31,6 @@ public class TripController {
                                                @Valid @RequestBody UpdateTripForm form,
                                                @AuthenticationPrincipal MemberPrincipal principal) {
         return ResponseEntity.ok(tripService.updateTrip(tripId, form, principal.getMember()));
-    }
-
-    @GetMapping("/members")
-    private ResponseEntity<Slice<MemberDto>> getAddableMembers(@AuthenticationPrincipal MemberPrincipal principal) {
-        return ResponseEntity.ok(tripService.getAddableMembers(principal.getMember()));
     }
 
     @GetMapping("/{tripId}/participants")

--- a/src/main/java/com/trip/diary/domain/model/Participant.java
+++ b/src/main/java/com/trip/diary/domain/model/Participant.java
@@ -1,0 +1,29 @@
+package com.trip.diary.domain.model;
+
+import com.trip.diary.domain.type.ParticipantType;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+@Getter
+@SuperBuilder
+@AllArgsConstructor
+@NoArgsConstructor
+@Entity
+public class Participant extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private ParticipantType type;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "trip_id")
+    private Trip trip;
+
+    @ManyToOne
+    @JoinColumn(name = "member_id")
+    private Member member;
+}

--- a/src/main/java/com/trip/diary/domain/model/Trip.java
+++ b/src/main/java/com/trip/diary/domain/model/Trip.java
@@ -1,0 +1,47 @@
+package com.trip.diary.domain.model;
+
+import com.trip.diary.dto.UpdateTripForm;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@SuperBuilder
+@AllArgsConstructor
+@NoArgsConstructor
+@Entity
+public class Trip extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String title;
+
+    private String description;
+
+    private LocalDateTime deletedAt;
+
+    private boolean isPrivate;
+
+    @ManyToOne
+    @JoinColumn(name = "leader_id")
+    private Member leader;
+
+    @Builder.Default
+    @OneToMany(mappedBy = "trip")
+    private List<Participant> participants = new ArrayList<>();
+
+    public void update(UpdateTripForm form){
+        this.isPrivate = form.isPrivate();
+        this.title = form.getTitle();
+        this.description = form.getDescription();
+    }
+}

--- a/src/main/java/com/trip/diary/domain/repository/MemberRepository.java
+++ b/src/main/java/com/trip/diary/domain/repository/MemberRepository.java
@@ -1,9 +1,12 @@
 package com.trip.diary.domain.repository;
 
 import com.trip.diary.domain.model.Member;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findByUsername(String username);
@@ -11,4 +14,8 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     boolean existsByUsername(String username);
 
     boolean existsByPhone(String phone);
+
+    List<Member> findAllByIdIn(Set<Long> ids);
+
+    Slice<Member> findByIdNot(Long id);
 }

--- a/src/main/java/com/trip/diary/domain/repository/ParticipantRepository.java
+++ b/src/main/java/com/trip/diary/domain/repository/ParticipantRepository.java
@@ -1,0 +1,9 @@
+package com.trip.diary.domain.repository;
+
+import com.trip.diary.domain.model.Participant;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ParticipantRepository extends JpaRepository<Participant, Long> {
+}

--- a/src/main/java/com/trip/diary/domain/repository/TripRepository.java
+++ b/src/main/java/com/trip/diary/domain/repository/TripRepository.java
@@ -1,0 +1,9 @@
+package com.trip.diary.domain.repository;
+
+import com.trip.diary.domain.model.Trip;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface TripRepository extends JpaRepository<Trip, Long> {
+}

--- a/src/main/java/com/trip/diary/domain/type/ParticipantType.java
+++ b/src/main/java/com/trip/diary/domain/type/ParticipantType.java
@@ -1,0 +1,5 @@
+package com.trip.diary.domain.type;
+
+public enum ParticipantType {
+    PENDING, ACCEPTED;
+}

--- a/src/main/java/com/trip/diary/dto/CreateTripDto.java
+++ b/src/main/java/com/trip/diary/dto/CreateTripDto.java
@@ -1,0 +1,33 @@
+package com.trip.diary.dto;
+
+import com.trip.diary.domain.model.Participant;
+import com.trip.diary.domain.model.Trip;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Getter
+public class CreateTripDto {
+    private Long id;
+    private String title;
+    private String description;
+    private List<ParticipantDto> participants;
+
+    public static CreateTripDto of(Trip trip, Long readerId, List<Participant> participants){
+        return CreateTripDto.builder()
+                .id(trip.getId())
+                .title(trip.getTitle())
+                .description(trip.getDescription())
+                .participants(participants.stream().map(participant ->
+                                ParticipantDto.of(participant, readerId))
+                                .collect(Collectors.toList()))
+                .build();
+    }
+}

--- a/src/main/java/com/trip/diary/dto/CreateTripForm.java
+++ b/src/main/java/com/trip/diary/dto/CreateTripForm.java
@@ -1,0 +1,28 @@
+package com.trip.diary.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.HashSet;
+import java.util.Set;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class CreateTripForm {
+    @NotBlank(message = "유효하지 않은 제목입니다.")
+    @Size(min = 1, max = 20, message = "1자 이상 20자 이하의 제목을 입력해주세요.")
+    private String title;
+
+    @Size(max = 100, message = "5자 이상 100자 이하의 설명을 입력해주세요.")
+    private String description;
+
+    private boolean isPrivate;
+
+    Set<Long> participants = new HashSet<>();
+}

--- a/src/main/java/com/trip/diary/dto/MemberDto.java
+++ b/src/main/java/com/trip/diary/dto/MemberDto.java
@@ -1,0 +1,25 @@
+package com.trip.diary.dto;
+
+import com.trip.diary.domain.model.Member;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Getter
+public class MemberDto {
+    private Long id;
+    private String nickname;
+    private String profileUrl;
+
+    public static MemberDto of(Member member) {
+        return MemberDto.builder()
+                .id(member.getId())
+                .nickname(member.getNickname())
+                .profileUrl(member.getProfileUrl())
+                .build();
+    }
+}

--- a/src/main/java/com/trip/diary/dto/ParticipantDto.java
+++ b/src/main/java/com/trip/diary/dto/ParticipantDto.java
@@ -1,0 +1,32 @@
+package com.trip.diary.dto;
+
+import com.trip.diary.domain.model.Participant;
+import com.trip.diary.domain.type.ParticipantType;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Getter
+public class ParticipantDto {
+    private Long id;
+    private String nickname;
+    private String profileUrl;
+    private boolean isAccepted;
+    private boolean isReader;
+
+    public static ParticipantDto of(Participant participant, Long readerId) {
+        boolean isReader = readerId.equals(participant.getMember().getId());
+        return ParticipantDto.builder()
+                .id(participant.getMember().getId())
+                .nickname(isReader ? participant.getMember().getNickname() + "(나)"
+                        : participant.getMember().getNickname())
+                .profileUrl(participant.getMember().getProfileUrl())
+                .isAccepted(participant.getType().equals(ParticipantType.ACCEPTED))
+                .isReader(isReader)
+                .build();
+    }
+}

--- a/src/main/java/com/trip/diary/dto/SignUpForm.java
+++ b/src/main/java/com/trip/diary/dto/SignUpForm.java
@@ -9,7 +9,7 @@ import lombok.*;
 @AllArgsConstructor
 @NoArgsConstructor
 public class SignUpForm {
-    @Size(min = 5, max = 20, message = "아이디는 5자 이상 20자 이하입니다.")
+    @Size(min = 5, max = 20, message = "5자 이상 20자 이하의 아이디를 입력해주세요.")
     private String username;
     private String password;
     @Size(min = 11, max = 11, message = "유효한 핸드폰 번호인지 확인해주세요")

--- a/src/main/java/com/trip/diary/dto/TripDto.java
+++ b/src/main/java/com/trip/diary/dto/TripDto.java
@@ -1,0 +1,30 @@
+package com.trip.diary.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.trip.diary.domain.model.Trip;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Getter
+public class TripDto {
+    private Long id;
+    private String title;
+    private String description;
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    private List<String> memberProfileUrls;
+
+    public static TripDto of(Trip trip){
+        return TripDto.builder()
+                .id(trip.getId())
+                .title(trip.getTitle())
+                .description(trip.getDescription())
+                .build();
+    }
+}

--- a/src/main/java/com/trip/diary/dto/UpdateTripForm.java
+++ b/src/main/java/com/trip/diary/dto/UpdateTripForm.java
@@ -1,0 +1,23 @@
+package com.trip.diary.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class UpdateTripForm {
+    @NotBlank(message = "유효하지 않은 제목입니다.")
+    @Size(min = 1, max = 20, message = "1자 이상 20자 이하의 제목을 입력해주세요.")
+    private String title;
+
+    @Size(max = 100, message = "5자 이상 100자 이하의 설명을 입력해주세요.")
+    private String description;
+
+    private boolean isPrivate;
+}

--- a/src/main/java/com/trip/diary/elasticsearch/model/MemberDocument.java
+++ b/src/main/java/com/trip/diary/elasticsearch/model/MemberDocument.java
@@ -1,0 +1,50 @@
+package com.trip.diary.elasticsearch.model;
+
+import com.trip.diary.domain.model.Member;
+import jakarta.persistence.Id;
+import lombok.*;
+import org.springframework.data.elasticsearch.annotations.Document;
+import org.springframework.data.elasticsearch.annotations.Field;
+import org.springframework.data.elasticsearch.annotations.FieldType;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@Setter
+@Document(indexName = "members")
+public class MemberDocument {
+    @Id
+    private Long id;
+
+    private String nickname;
+
+    private String profileUrl;
+
+    @Field(type = FieldType.Nested)
+    @Builder.Default
+    private List<Trip> trips = new ArrayList<>();
+
+    @AllArgsConstructor
+    @Getter
+    public static class Trip {
+        @Field(type = FieldType.Long)
+        private Long id;
+    }
+
+
+    public static MemberDocument of(Member member) {
+        return MemberDocument.builder()
+                .id(member.getId())
+                .nickname(member.getNickname())
+                .profileUrl(member.getProfileUrl())
+                .build();
+    }
+
+    public void addTripId(Long tripId) {
+        trips.add(new Trip(tripId));
+    }
+}

--- a/src/main/java/com/trip/diary/elasticsearch/repository/MemberSearchRepository.java
+++ b/src/main/java/com/trip/diary/elasticsearch/repository/MemberSearchRepository.java
@@ -1,0 +1,13 @@
+package com.trip.diary.elasticsearch.repository;
+
+import com.trip.diary.elasticsearch.model.MemberDocument;
+import org.springframework.data.elasticsearch.repository.ElasticsearchRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Set;
+
+@Repository
+public interface MemberSearchRepository extends ElasticsearchRepository<MemberDocument, Long> {
+    List<MemberDocument> findByIdIn(Set<Long> ids);
+}

--- a/src/main/java/com/trip/diary/event/MemberEventHandler.java
+++ b/src/main/java/com/trip/diary/event/MemberEventHandler.java
@@ -1,0 +1,22 @@
+package com.trip.diary.event;
+
+import com.trip.diary.elasticsearch.model.MemberDocument;
+import com.trip.diary.event.dto.MemberRegisterEvent;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Component
+@RequiredArgsConstructor
+public class MemberEventHandler {
+    private final ElasticsearchOperations elasticsearchOperations;
+
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void addMemberToElasticSearch(MemberRegisterEvent event){
+        elasticsearchOperations.save(MemberDocument.of(event.getMember()));
+    }
+}

--- a/src/main/java/com/trip/diary/event/TripEventHandler.java
+++ b/src/main/java/com/trip/diary/event/TripEventHandler.java
@@ -1,0 +1,41 @@
+package com.trip.diary.event;
+
+import com.trip.diary.elasticsearch.repository.MemberSearchRepository;
+import com.trip.diary.event.dto.TripInviteEvent;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
+import org.springframework.data.elasticsearch.core.mapping.IndexCoordinates;
+import org.springframework.data.elasticsearch.core.query.UpdateQuery;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Component
+@RequiredArgsConstructor
+public class TripEventHandler {
+
+    private final MemberSearchRepository memberSearchRepository;
+    private final ElasticsearchOperations elasticsearchOperations;
+
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void addMemberToElasticSearch(TripInviteEvent event) {
+        List<UpdateQuery> updateQueries = memberSearchRepository.findByIdIn(event.getParticipantsIds())
+                .stream().map(
+                        memberDocument ->
+                        {
+                            memberDocument.addTripId(event.getTripId());
+                            return UpdateQuery.builder(memberDocument.getId().toString())
+                                    .withDocument(elasticsearchOperations.getElasticsearchConverter().mapObject(memberDocument))
+                                    .withDocAsUpsert(true)
+                                    .build();
+                        }
+                ).collect(Collectors.toList());
+
+        elasticsearchOperations.bulkUpdate(updateQueries, IndexCoordinates.of("members"));
+    }
+}

--- a/src/main/java/com/trip/diary/event/dto/MemberRegisterEvent.java
+++ b/src/main/java/com/trip/diary/event/dto/MemberRegisterEvent.java
@@ -1,0 +1,11 @@
+package com.trip.diary.event.dto;
+
+import com.trip.diary.domain.model.Member;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class MemberRegisterEvent {
+    private Member member;
+}

--- a/src/main/java/com/trip/diary/event/dto/TripInviteEvent.java
+++ b/src/main/java/com/trip/diary/event/dto/TripInviteEvent.java
@@ -1,0 +1,13 @@
+package com.trip.diary.event.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.Set;
+
+@Getter
+@AllArgsConstructor
+public class TripInviteEvent {
+    private Set<Long> participantsIds;
+    private Long tripId;
+}

--- a/src/main/java/com/trip/diary/exception/ErrorCode.java
+++ b/src/main/java/com/trip/diary/exception/ErrorCode.java
@@ -10,7 +10,12 @@ public enum ErrorCode {
     NOT_FOUND_MEMBER(HttpStatus.BAD_REQUEST, "해당 유저를 찾을 수 없습니다."),
     PASSWORD_UNMATCHED(HttpStatus.BAD_REQUEST, "비밀번호가 일치하지 않습니다."),
     MOBILE_ALREADY_REGISTERED(HttpStatus.BAD_REQUEST, "이미 존재하는 전화 번호입니다."),
-    ID_ALREADY_USED(HttpStatus.BAD_REQUEST, "이미 존재하는 아이디입니다.");
+    ID_ALREADY_USED(HttpStatus.BAD_REQUEST, "이미 존재하는 아이디입니다."),
+
+    NOT_FOUND_TRIP(HttpStatus.BAD_REQUEST, "해당 여행 기록장을 찾을 수 없습니다."),
+    NOT_AUTHORITY_READ_TRIP(HttpStatus.BAD_REQUEST, "해당 여행 기록장을 열람할 수 없습니다."),
+    NOT_AUTHORITY_WRITE_TRIP(HttpStatus.BAD_REQUEST, "해당 여행 기록장을 열람할 수 없습니다."),
+    ;
     private final HttpStatus httpStatus;
     private final String detail;
 }

--- a/src/main/java/com/trip/diary/service/AuthService.java
+++ b/src/main/java/com/trip/diary/service/AuthService.java
@@ -5,15 +5,21 @@ import com.trip.diary.domain.repository.MemberRepository;
 import com.trip.diary.dto.SignInForm;
 import com.trip.diary.dto.SignUpForm;
 import com.trip.diary.dto.TokenDto;
+import com.trip.diary.elasticsearch.model.MemberDocument;
+import com.trip.diary.event.dto.MemberRegisterEvent;
 import com.trip.diary.exception.CustomException;
 import com.trip.diary.exception.ErrorCode;
 import com.trip.diary.security.TokenProvider;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
-import static com.trip.diary.exception.ErrorCode.*;
+import static com.trip.diary.exception.ErrorCode.ID_ALREADY_USED;
+import static com.trip.diary.exception.ErrorCode.MOBILE_ALREADY_REGISTERED;
 
 @Service
 @Slf4j
@@ -25,6 +31,9 @@ public class AuthService {
 
     private final MemberRepository memberRepository;
 
+    private final ApplicationEventPublisher applicationEventPublisher;
+
+    @Transactional
     public void register(SignUpForm form) {
         if (memberRepository.existsByUsername(form.getUsername())) {
             throw new CustomException(ID_ALREADY_USED);
@@ -36,7 +45,7 @@ public class AuthService {
 
         form.setPassword(passwordEncoder.encode(form.getPassword()));
 
-        memberRepository.save(
+        Member savedMember = memberRepository.save(
                 Member.builder()
                         .username(form.getUsername())
                         .password(form.getPassword())
@@ -44,6 +53,8 @@ public class AuthService {
                         .nickname(form.getNickname())
                         .build()
         );
+
+        applicationEventPublisher.publishEvent(new MemberRegisterEvent(savedMember));
     }
 
     public TokenDto authenticate(SignInForm form) {

--- a/src/main/java/com/trip/diary/service/TripService.java
+++ b/src/main/java/com/trip/diary/service/TripService.java
@@ -70,10 +70,6 @@ public class TripService {
                 ).collect(Collectors.toList());
     }
 
-    public Slice<MemberDto> getAddableMembers(Member member) {
-        return memberRepository.findByIdNot(member.getId())
-                .map(MemberDto::of);
-    }
 
     @Transactional
     public List<ParticipantDto> getTripParticipants(Long tripId, Member member) {
@@ -94,7 +90,7 @@ public class TripService {
     }
 
     private boolean isMemberTripParticipants(List<Participant> participants, Long memberId) {
-        return participants.stream().anyMatch(participant -> participant.getId().equals(memberId));
+        return participants.stream().anyMatch(participant -> participant.getMember().getId().equals(memberId));
     }
 
 

--- a/src/main/java/com/trip/diary/service/TripService.java
+++ b/src/main/java/com/trip/diary/service/TripService.java
@@ -1,0 +1,107 @@
+package com.trip.diary.service;
+
+import com.trip.diary.domain.model.Member;
+import com.trip.diary.domain.model.Participant;
+import com.trip.diary.domain.model.Trip;
+import com.trip.diary.domain.repository.MemberRepository;
+import com.trip.diary.domain.repository.ParticipantRepository;
+import com.trip.diary.domain.repository.TripRepository;
+import com.trip.diary.dto.*;
+import com.trip.diary.exception.CustomException;
+import com.trip.diary.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Slice;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static com.trip.diary.domain.type.ParticipantType.ACCEPTED;
+import static com.trip.diary.domain.type.ParticipantType.PENDING;
+import static com.trip.diary.exception.ErrorCode.NOT_AUTHORITY_WRITE_TRIP;
+import static com.trip.diary.exception.ErrorCode.NOT_FOUND_TRIP;
+
+@Service
+@RequiredArgsConstructor
+public class TripService {
+
+    private final TripRepository tripRepository;
+
+    private final MemberRepository memberRepository;
+
+    private final ParticipantRepository participantRepository;
+
+
+    @Transactional
+    public CreateTripDto create(CreateTripForm form, Member member) {
+        Trip trip = tripRepository.save(
+                Trip.builder()
+                        .title(form.getTitle())
+                        .description(form.getDescription())
+                        .leader(member)
+                        .isPrivate(form.isPrivate())
+                        .build()
+        );
+
+        Set<Long> participantsIds = form.getParticipants();
+        participantsIds.add(member.getId());
+        return CreateTripDto.of(trip, member.getId(),
+                participantRepository.saveAll(getParticipants(participantsIds, trip)));
+    }
+
+    private List<Participant> getParticipants(Set<Long> participantsIds, Trip trip) {
+        Long leaderId = trip.getLeader().getId();
+        return memberRepository.findAllByIdIn(participantsIds)
+                .stream()
+                .map(member -> Participant.builder()
+                        .trip(trip)
+                        .type(Objects.equals(member.getId(), leaderId) ? ACCEPTED : PENDING)
+                        .member(member)
+                        .build()
+                ).collect(Collectors.toList());
+    }
+
+    public Slice<MemberDto> getAddableMembers(Member member) {
+        return memberRepository.findByIdNot(member.getId())
+                .map(MemberDto::of);
+    }
+
+    @Transactional
+    public List<ParticipantDto> getTripParticipants(Long tripId, Member member) {
+        Trip trip = tripRepository.findById(tripId)
+                .orElseThrow(() -> new CustomException(NOT_FOUND_TRIP));
+
+        List<Participant> participants = trip.getParticipants();
+
+        if (trip.isPrivate() && !isMemberTripParticipants(participants, member.getId())) {
+            throw new CustomException(ErrorCode.NOT_AUTHORITY_READ_TRIP);
+        }
+
+        return participants
+                .stream()
+                .map(participant ->
+                        ParticipantDto.of(participant, member.getId()))
+                .collect(Collectors.toList());
+    }
+
+    private boolean isMemberTripParticipants(List<Participant> participants, Long memberId) {
+        return participants.stream().anyMatch(participant -> participant.getId().equals(memberId));
+    }
+
+
+    public TripDto updateTrip(Long tripId, UpdateTripForm form, Member member) {
+        Trip trip = tripRepository.findById(tripId)
+                .orElseThrow(() -> new CustomException(NOT_FOUND_TRIP));
+
+        if(!Objects.equals(trip.getLeader().getId(), member.getId())){
+            throw new CustomException(NOT_AUTHORITY_WRITE_TRIP);
+        }
+
+        trip.update(form);
+
+        return TripDto.of(tripRepository.save(trip));
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -22,5 +22,10 @@ spring:
   h2:
     console:
       enabled: true
+  data:
+    elasticsearch:
+      repositories:
+        enabled: true
+      url: localhost:9200
   jwt:
     secret: d29uc2Vvbnp6YW5nCg==

--- a/src/main/resources/request.http
+++ b/src/main/resources/request.http
@@ -3,10 +3,10 @@ POST http://localhost:8080/auth/signup
 Content-Type: application/json
 
 {
-  "username" : "thdefn2",
+  "username" : "ododieod",
   "password" : "1234",
-  "nickname" : "daru",
-  "phone" : "01041230233"
+  "nickname" : "odie",
+  "phone" : "01041230232"
 }
 
 ### 로그인
@@ -16,4 +16,38 @@ Content-Type: application/json
 {
   "username" : "thdefn",
   "password" : "1234"
+}
+
+### 기록장 만들기
+POST http://localhost:8080/trips
+Content-Type: application/json
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ0aGRlZm4iLCJpYXQiOjE2ODM2NDEzMjUsImV4cCI6MTY4MzY0NDkyNX0.pXS9rpNyaRhGIfExU0drP6lGY6r-d_WYccuYQqYz3-U
+
+{
+  "title" : "제주도 여행 3명괌",
+  "description" : "제주도 여행을 간다",
+  "isPrivate" : true,
+  "participants" : [2]
+}
+
+### 기록장에 초대할 유저 리스트 조회
+GET http://localhost:8080/trips/members
+Content-Type: application/json
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ0aGRlZm4iLCJpYXQiOjE2ODM2Nzc4ODcsImV4cCI6MTY4MzY4MTQ4N30.e_yjEUQyDYLiuuINhX9vgFgWRY3JlMxkjV5lCxu59no
+
+### 기록장에 초대한 유저 리스트 조회
+GET http://localhost:8080/trips/2/participants
+Content-Type: application/json
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ0aGRlZm4iLCJpYXQiOjE2ODM2ODE2ODIsImV4cCI6MTY4MzY4NTI4Mn0.XeTqtVn2DDe9CYJkFeT1xixOjqdFlP1BPs6ouquNeFY
+
+
+### 기록장 업데이트
+PUT http://localhost:8080/trips/2
+Content-Type: application/json
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ0aGRlZm4iLCJpYXQiOjE2ODM2ODE2ODIsImV4cCI6MTY4MzY4NTI4Mn0.XeTqtVn2DDe9CYJkFeT1xixOjqdFlP1BPs6ouquNeFY
+
+{
+  "title" : "제주도 여행이 아니라 강릉 여행? ",
+  "description" : "제주도 여행인줄 알았으나 강릉 여행이예욧",
+  "isPrivate" : false
 }

--- a/src/main/resources/request.http
+++ b/src/main/resources/request.http
@@ -3,10 +3,10 @@ POST http://localhost:8080/auth/signup
 Content-Type: application/json
 
 {
-  "username" : "ododieod",
+  "username" : "thistimeisnotdawn",
   "password" : "1234",
-  "nickname" : "odie",
-  "phone" : "01041230232"
+  "nickname" : "새벽이아님",
+  "phone" : "01023456669"
 }
 
 ### 로그인
@@ -14,20 +14,20 @@ POST http://localhost:8080/auth/signin
 Content-Type: application/json
 
 {
-  "username" : "thdefn",
+  "username" : "thistimeisnotdawn",
   "password" : "1234"
 }
 
 ### 기록장 만들기
 POST http://localhost:8080/trips
 Content-Type: application/json
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ0aGRlZm4iLCJpYXQiOjE2ODM2NDEzMjUsImV4cCI6MTY4MzY0NDkyNX0.pXS9rpNyaRhGIfExU0drP6lGY6r-d_WYccuYQqYz3-U
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ0aGlzdGltZWlzbm90ZGF3biIsImlhdCI6MTY4Mzg0MjIwMywiZXhwIjoxNjgzODQ1ODAzfQ.D6hZdPh6Duourf32Vn9I5WwvMZ5T1ghF5zfyTKDJOqY
 
 {
-  "title" : "제주도 여행 3명괌",
-  "description" : "제주도 여행을 간다",
-  "isPrivate" : true,
-  "participants" : [2]
+  "title" : "강릉 여행 마지막...",
+  "description" : "강릉 여행을 갈거다..",
+  "isPrivate" : false,
+  "participants" : [3, 7, 8]
 }
 
 ### 기록장에 초대할 유저 리스트 조회

--- a/src/test/java/com/trip/diary/TripApplicationTests.java
+++ b/src/test/java/com/trip/diary/TripApplicationTests.java
@@ -18,57 +18,57 @@ import java.util.stream.Collectors;
 @SpringBootTest
 class TripApplicationTests {
 
-    @Autowired
-    private MemberSearchRepository memberSearchRepository;
-
-    @Autowired
-    private ElasticsearchOperations elasticsearchOperations;
+//    @Autowired
+//    private MemberSearchRepository memberSearchRepository;
+//
+//    @Autowired
+//    private ElasticsearchOperations elasticsearchOperations;
 
     @Test
     void contextLoads() {
     }
 
-    @Test
-    void test() {
-        //given
-        Page<MemberDocument> memberDocuments = memberSearchRepository.findAll(Pageable.ofSize(5));
-        //when
-        memberDocuments.getContent().stream()
-                .forEach(memberDocument -> {
-                    System.out.println(memberDocument.getId());
-                    System.out.println("trip-->" + memberDocument.getTrips());
-                });
-        //then
-    }
-
-    @Test
-    void test2() {
-        //given
-        List<MemberDocument> memberDocuments = memberSearchRepository.findByIdIn(Set.of(3L,5L,6L,8L));
-        //when
-        memberDocuments.stream()
-                .forEach(memberDocument -> {
-                    System.out.println(memberDocument.getId());
-                    System.out.println("trip-->" + memberDocument.getTrips().get(0).getId());
-                });
-        //then
-    }
-
-    @Test
-    void test3() {
-        List<UpdateQuery> updateQueries = memberSearchRepository.findByIdIn(Set.of(3L, 7L, 8L, 10L))
-                .stream().map(
-                        memberDocument ->
-                        {
-                            memberDocument.addTripId(4L);
-                            return UpdateQuery.builder(memberDocument.getId().toString())
-                                    .withDocument(elasticsearchOperations.getElasticsearchConverter().mapObject(memberDocument))
-                                    .withDocAsUpsert(true)
-                                    .build();
-                        }
-                ).collect(Collectors.toList());
-
-        //elasticsearchOperations.bulkUpdate(updateQueries, IndexCoordinates.of("members"));
-    }
+//    @Test
+//    void test() {
+//        //given
+//        Page<MemberDocument> memberDocuments = memberSearchRepository.findAll(Pageable.ofSize(5));
+//        //when
+//        memberDocuments.getContent().stream()
+//                .forEach(memberDocument -> {
+//                    System.out.println(memberDocument.getId());
+//                    System.out.println("trip-->" + memberDocument.getTrips());
+//                });
+//        //then
+//    }
+//
+//    @Test
+//    void test2() {
+//        //given
+//        List<MemberDocument> memberDocuments = memberSearchRepository.findByIdIn(Set.of(3L,5L,6L,8L));
+//        //when
+//        memberDocuments.stream()
+//                .forEach(memberDocument -> {
+//                    System.out.println(memberDocument.getId());
+//                    System.out.println("trip-->" + memberDocument.getTrips().get(0).getId());
+//                });
+//        //then
+//    }
+//
+//    @Test
+//    void test3() {
+//        List<UpdateQuery> updateQueries = memberSearchRepository.findByIdIn(Set.of(3L, 7L, 8L, 10L))
+//                .stream().map(
+//                        memberDocument ->
+//                        {
+//                            memberDocument.addTripId(4L);
+//                            return UpdateQuery.builder(memberDocument.getId().toString())
+//                                    .withDocument(elasticsearchOperations.getElasticsearchConverter().mapObject(memberDocument))
+//                                    .withDocAsUpsert(true)
+//                                    .build();
+//                        }
+//                ).collect(Collectors.toList());
+//
+//        //elasticsearchOperations.bulkUpdate(updateQueries, IndexCoordinates.of("members"));
+//    }
 
 }

--- a/src/test/java/com/trip/diary/TripApplicationTests.java
+++ b/src/test/java/com/trip/diary/TripApplicationTests.java
@@ -1,13 +1,74 @@
 package com.trip.diary;
 
+import com.trip.diary.elasticsearch.model.MemberDocument;
+import com.trip.diary.elasticsearch.repository.MemberSearchRepository;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
+import org.springframework.data.elasticsearch.core.mapping.IndexCoordinates;
+import org.springframework.data.elasticsearch.core.query.UpdateQuery;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 @SpringBootTest
 class TripApplicationTests {
 
+    @Autowired
+    private MemberSearchRepository memberSearchRepository;
+
+    @Autowired
+    private ElasticsearchOperations elasticsearchOperations;
+
     @Test
     void contextLoads() {
+    }
+
+    @Test
+    void test() {
+        //given
+        Page<MemberDocument> memberDocuments = memberSearchRepository.findAll(Pageable.ofSize(5));
+        //when
+        memberDocuments.getContent().stream()
+                .forEach(memberDocument -> {
+                    System.out.println(memberDocument.getId());
+                    System.out.println("trip-->" + memberDocument.getTrips());
+                });
+        //then
+    }
+
+    @Test
+    void test2() {
+        //given
+        List<MemberDocument> memberDocuments = memberSearchRepository.findByIdIn(Set.of(3L,5L,6L,8L));
+        //when
+        memberDocuments.stream()
+                .forEach(memberDocument -> {
+                    System.out.println(memberDocument.getId());
+                    System.out.println("trip-->" + memberDocument.getTrips().get(0).getId());
+                });
+        //then
+    }
+
+    @Test
+    void test3() {
+        List<UpdateQuery> updateQueries = memberSearchRepository.findByIdIn(Set.of(3L, 7L, 8L, 10L))
+                .stream().map(
+                        memberDocument ->
+                        {
+                            memberDocument.addTripId(4L);
+                            return UpdateQuery.builder(memberDocument.getId().toString())
+                                    .withDocument(elasticsearchOperations.getElasticsearchConverter().mapObject(memberDocument))
+                                    .withDocAsUpsert(true)
+                                    .build();
+                        }
+                ).collect(Collectors.toList());
+
+        //elasticsearchOperations.bulkUpdate(updateQueries, IndexCoordinates.of("members"));
     }
 
 }

--- a/src/test/java/com/trip/diary/controller/TripControllerTest.java
+++ b/src/test/java/com/trip/diary/controller/TripControllerTest.java
@@ -1,0 +1,146 @@
+package com.trip.diary.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.trip.diary.dto.*;
+import com.trip.diary.mockuser.WithMockCustomUser;
+import com.trip.diary.service.TripService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = TripController.class)
+@AutoConfigureMockMvc(addFilters = false)
+class TripControllerTest {
+
+    @MockBean
+    private TripService tripService;
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    private static final String TOKEN = "Bearer token";
+
+    @Test
+    @WithMockCustomUser
+    @DisplayName("여행 기록장 생성 성공")
+    void createTripTest_success() throws Exception {
+        //given
+        CreateTripForm form = CreateTripForm.builder()
+                .title("제주도 여행팟")
+                .description("제주도 여행을 떠나요")
+                .isPrivate(true)
+                .participants(new HashSet<>(Arrays.asList(2L, 3L)))
+                .build();
+        given(tripService.create(any(), any()))
+                .willReturn(CreateTripDto.builder()
+                        .id(1L)
+                        .title("제주도 여행팟")
+                        .description("제주도 여행을 떠나요")
+                        .participants(
+                                List.of(ParticipantDto.builder()
+                                        .isAccepted(true)
+                                        .isReader(true)
+                                        .nickname("하이")
+                                        .profileUrl(null)
+                                        .id(2L)
+                                        .build())
+                        )
+                        .build()
+                );
+        //when
+        //then
+        mockMvc.perform(post("/trips")
+                        .header("Authorization", TOKEN)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(form))
+
+                )
+                .andDo(print())
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @WithMockCustomUser
+    @DisplayName("여행 기록장 수정 성공")
+    void updateTripTest_success() throws Exception {
+        //given
+        UpdateTripForm form = UpdateTripForm.builder()
+                .title("제주도 여행팟")
+                .description("제주도 여행을 떠나요")
+                .isPrivate(true)
+                .build();
+        given(tripService.updateTrip(anyLong(), any(), any()))
+                .willReturn(TripDto.builder()
+                        .id(1L)
+                        .title("임의의 타이틀")
+                        .description("임의의 설명")
+                        .memberProfileUrls(List.of("basic.jpg", "basic.jpg"))
+                        .build()
+                );
+        //when
+        //then
+        mockMvc.perform(put("/trips/{tripId}", 1L)
+                        .header("Authorization", TOKEN)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(form))
+
+                )
+                .andDo(print())
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @WithMockCustomUser
+    @DisplayName("여행 참여 멤버 조회 성공")
+    void getTripParticipantsTest_success() throws Exception {
+        //given
+        given(tripService.getTripParticipants(anyLong(), any()))
+                .willReturn(
+                        List.of(
+                                ParticipantDto.builder()
+                                        .id(1L)
+                                        .isAccepted(true)
+                                        .isReader(true)
+                                        .nickname("안녕")
+                                        .profileUrl("basic.jpg")
+                                        .build(),
+                                ParticipantDto.builder()
+                                        .id(2L)
+                                        .isAccepted(true)
+                                        .isReader(false)
+                                        .nickname("정희")
+                                        .profileUrl("basic.jpg")
+                                        .build()
+                        )
+                );
+        //when
+        //then
+        mockMvc.perform(get("/trips/{tripId}/participants", 1L)
+                        .header("Authorization", TOKEN)
+                        .contentType(MediaType.APPLICATION_JSON)
+
+                )
+                .andDo(print())
+                .andExpect(status().isOk());
+    }
+
+}

--- a/src/test/java/com/trip/diary/mockuser/WithMockCustomUser.java
+++ b/src/test/java/com/trip/diary/mockuser/WithMockCustomUser.java
@@ -1,0 +1,11 @@
+package com.trip.diary.mockuser;
+
+import org.springframework.security.test.context.support.WithSecurityContext;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+@Retention(RetentionPolicy.RUNTIME)
+@WithSecurityContext(factory = WithMockCustomUserSecurityContextFactory.class)
+public @interface WithMockCustomUser {
+}

--- a/src/test/java/com/trip/diary/mockuser/WithMockCustomUserSecurityContextFactory.java
+++ b/src/test/java/com/trip/diary/mockuser/WithMockCustomUserSecurityContextFactory.java
@@ -1,0 +1,33 @@
+package com.trip.diary.mockuser;
+
+import com.trip.diary.domain.model.Member;
+import com.trip.diary.domain.type.MemberType;
+import com.trip.diary.security.MemberPrincipal;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.test.context.support.WithSecurityContextFactory;
+
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public class WithMockCustomUserSecurityContextFactory implements WithSecurityContextFactory<WithMockCustomUser> {
+    private static final Member member = Member.builder()
+            .username("qwerty99")
+            .nickname("김맹맹")
+            .password("1234567")
+            .phone("01011111111")
+            .build();
+
+    @Override
+    public SecurityContext createSecurityContext(WithMockCustomUser annotation) {
+        SecurityContext context = SecurityContextHolder.createEmptyContext();
+        Authentication authentication = new UsernamePasswordAuthenticationToken(new MemberPrincipal(member), "",
+                Stream.of(MemberType.USER.name()).map(SimpleGrantedAuthority::new)
+                        .collect(Collectors.toList()));
+        context.setAuthentication(authentication);
+        return context;
+    }
+}

--- a/src/test/java/com/trip/diary/service/AuthServiceTest.java
+++ b/src/test/java/com/trip/diary/service/AuthServiceTest.java
@@ -2,7 +2,9 @@ package com.trip.diary.service;
 
 import com.trip.diary.domain.model.Member;
 import com.trip.diary.domain.repository.MemberRepository;
+import com.trip.diary.dto.SignInForm;
 import com.trip.diary.dto.SignUpForm;
+import com.trip.diary.dto.TokenDto;
 import com.trip.diary.exception.CustomException;
 import com.trip.diary.exception.ErrorCode;
 import com.trip.diary.security.TokenProvider;
@@ -15,6 +17,8 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
@@ -40,6 +44,13 @@ class AuthServiceTest {
     @InjectMocks
     private AuthService authService;
 
+    Member member = Member.builder()
+            .username("qwerty99")
+            .nickname("김맹맹")
+            .password("1234567")
+            .phone("01011111111")
+            .build();
+
     @Test
     @DisplayName("회원가입 성공")
     void registerTest_success() {
@@ -53,14 +64,7 @@ class AuthServiceTest {
         given(memberRepository.existsByUsername(anyString())).willReturn(false);
         given(memberRepository.existsByPhone(anyString())).willReturn(false);
         given(passwordEncoder.encode(anyString())).willReturn("encodedpassword");
-        given(memberRepository.save(any()))
-                .willReturn(Member.builder()
-                        .username("qwerty99")
-                        .nickname("김맹맹")
-                        .password("1234567")
-                        .phone("01011111111")
-                        .build()
-                );
+        given(memberRepository.save(any())).willReturn(member);
         //when
         ArgumentCaptor<Member> captor = ArgumentCaptor.forClass(Member.class);
         authService.register(form);
@@ -106,6 +110,56 @@ class AuthServiceTest {
                 () -> authService.register(form));
         //then
         assertEquals(exception.getErrorCode(), ErrorCode.MOBILE_ALREADY_REGISTERED);
+    }
+
+    @Test
+    @DisplayName("로그인 성공")
+    void authenticateTest_success() {
+        //given
+        SignInForm form = SignInForm.builder()
+                .username("qwerty99")
+                .password("1234567")
+                .build();
+        given(memberRepository.findByUsername(anyString())).willReturn(Optional.of(member));
+        given(passwordEncoder.matches(any(), anyString())).willReturn(true);
+        given(tokenProvider.generateToken(anyString())).willReturn("Bearer tokenstring");
+        //when
+        TokenDto tokenDto = authService.authenticate(form);
+        //then
+        assertEquals("Bearer tokenstring", tokenDto.getAccessToken());
+    }
+
+    @Test
+    @DisplayName("로그인 실패 - 해당 아이디와 일치하는 유저 없음")
+    void authenticateTest_failWhenNotFoundMember() {
+        //given
+        SignInForm form = SignInForm.builder()
+                .username("qwerty99")
+                .password("1234567")
+                .build();
+        given(memberRepository.findByUsername(anyString())).willReturn(Optional.empty());
+        //when
+        CustomException exception = assertThrows(CustomException.class,
+                () -> authService.authenticate(form));
+        //then
+        assertEquals(ErrorCode.NOT_FOUND_MEMBER, exception.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("로그인 실패 - 패스워드가 다름")
+    void authenticateTest_failWhenPasswordUnmatched() {
+        //given
+        SignInForm form = SignInForm.builder()
+                .username("qwerty99")
+                .password("1234567")
+                .build();
+        given(memberRepository.findByUsername(anyString())).willReturn(Optional.of(member));
+        given(passwordEncoder.matches(any(), anyString())).willReturn(false);
+        //when
+        CustomException exception = assertThrows(CustomException.class,
+                () -> authService.authenticate(form));
+        //then
+        assertEquals(ErrorCode.PASSWORD_UNMATCHED, exception.getErrorCode());
     }
 
 }

--- a/src/test/java/com/trip/diary/service/AuthServiceTest.java
+++ b/src/test/java/com/trip/diary/service/AuthServiceTest.java
@@ -13,9 +13,11 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.times;
@@ -28,6 +30,9 @@ class AuthServiceTest {
 
     @Mock
     private TokenProvider tokenProvider;
+
+    @Mock
+    private ApplicationEventPublisher applicationEventPublisher;
 
     @Mock
     private PasswordEncoder passwordEncoder;
@@ -48,6 +53,14 @@ class AuthServiceTest {
         given(memberRepository.existsByUsername(anyString())).willReturn(false);
         given(memberRepository.existsByPhone(anyString())).willReturn(false);
         given(passwordEncoder.encode(anyString())).willReturn("encodedpassword");
+        given(memberRepository.save(any()))
+                .willReturn(Member.builder()
+                        .username("qwerty99")
+                        .nickname("김맹맹")
+                        .password("1234567")
+                        .phone("01011111111")
+                        .build()
+                );
         //when
         ArgumentCaptor<Member> captor = ArgumentCaptor.forClass(Member.class);
         authService.register(form);

--- a/src/test/java/com/trip/diary/service/TripServiceTest.java
+++ b/src/test/java/com/trip/diary/service/TripServiceTest.java
@@ -1,0 +1,392 @@
+package com.trip.diary.service;
+
+import com.trip.diary.domain.model.Member;
+import com.trip.diary.domain.model.Participant;
+import com.trip.diary.domain.model.Trip;
+import com.trip.diary.domain.repository.MemberRepository;
+import com.trip.diary.domain.repository.ParticipantRepository;
+import com.trip.diary.domain.repository.TripRepository;
+import com.trip.diary.domain.type.ParticipantType;
+import com.trip.diary.dto.*;
+import com.trip.diary.exception.CustomException;
+import com.trip.diary.exception.ErrorCode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class TripServiceTest {
+    @Mock
+    private TripRepository tripRepository;
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @Mock
+    private ParticipantRepository participantRepository;
+
+    @Mock
+    private ApplicationEventPublisher applicationEventPublisher;
+
+    @InjectMocks
+    private TripService tripService;
+
+    Member member = Member.builder()
+            .id(1L)
+            .username("qwerty99")
+            .nickname("김맹맹")
+            .password("1234567")
+            .profileUrl(null)
+            .phone("01011111111")
+            .build();
+
+    Trip trip = Trip.builder()
+            .id(1L)
+            .title("임의의 타이틀")
+            .isPrivate(true)
+            .description("임의의 설명")
+            .leader(member)
+            .build();
+
+    Member participant1 = Member.builder()
+            .id(2L)
+            .username("abcde")
+            .nickname("하이")
+            .profileUrl(null)
+            .build();
+    Member participant2 = Member.builder()
+            .id(3L)
+            .username("abcde")
+            .nickname("하이")
+            .profileUrl(null)
+            .build();
+
+    @Test
+    @DisplayName("여행 기록장 생성 성공")
+    void createTest_success() {
+        //given
+        CreateTripForm form = CreateTripForm.builder()
+                .title("제주도 여행팟")
+                .description("제주도 여행을 떠나요")
+                .isPrivate(true)
+                .participants(new HashSet<>(Arrays.asList(2L, 3L)))
+                .build();
+        given(tripRepository.save(any())).willReturn(trip);
+        given(memberRepository.findAllByIdIn(any()))
+                .willReturn(List.of(participant1, participant2));
+        given(participantRepository.saveAll(any()))
+                .willReturn(List.of(Participant.builder()
+                                .trip(trip)
+                                .member(member)
+                                .type(ParticipantType.ACCEPTED)
+                                .build(),
+                        Participant.builder()
+                                .trip(trip)
+                                .member(participant1)
+                                .type(ParticipantType.PENDING)
+                                .build(),
+                        Participant.builder()
+                                .trip(trip)
+                                .member(participant2)
+                                .type(ParticipantType.PENDING)
+                                .build()
+                ));
+        //when
+        CreateTripDto result = tripService.create(form, member);
+        //then
+        assertEquals(trip.getDescription(), result.getDescription());
+        assertEquals(3, result.getParticipants().size());
+        assertEquals(member.getId(), result.getParticipants().get(0).getId());
+        assertNotEquals(member.getNickname(), result.getParticipants().get(0).getNickname());
+        assertEquals(participant1.getNickname(), result.getParticipants().get(1).getNickname());
+        assertFalse(result.getParticipants().get(1).isAccepted());
+        assertFalse(result.getParticipants().get(1).isReader());
+    }
+
+    @Test
+    @DisplayName("여행 기록장 생성 성공 - form 이 리더의 아이디도 포함한 경우")
+    void createTest_successWhenParticipantsFormContainLeaderId() {
+        //given
+        CreateTripForm form = CreateTripForm.builder()
+                .title("제주도 여행팟")
+                .description("제주도 여행을 떠나요")
+                .isPrivate(true)
+                .participants(new HashSet<>(Arrays.asList(1L, 2L, 3L)))
+                .build();
+        given(tripRepository.save(any())).willReturn(trip);
+        given(memberRepository.findAllByIdIn(any()))
+                .willReturn(List.of(participant1, participant2));
+        given(participantRepository.saveAll(any()))
+                .willReturn(List.of(Participant.builder()
+                                .trip(trip)
+                                .member(member)
+                                .type(ParticipantType.ACCEPTED)
+                                .build(),
+                        Participant.builder()
+                                .trip(trip)
+                                .member(participant1)
+                                .type(ParticipantType.PENDING)
+                                .build(),
+                        Participant.builder()
+                                .trip(trip)
+                                .member(participant2)
+                                .type(ParticipantType.PENDING)
+                                .build()
+                ));
+        //when
+        CreateTripDto result = tripService.create(form, member);
+        //then
+        assertEquals(trip.getDescription(), result.getDescription());
+        assertEquals(3, result.getParticipants().size());
+    }
+
+    @Test
+    @DisplayName("여행 기록장 수정 성공")
+    void updateTripTest_success() {
+        //given
+        UpdateTripForm form = UpdateTripForm.builder()
+                .title("강릉 여행팟")
+                .description("강릉 여행을 5/13-5/20일 간다")
+                .isPrivate(false)
+                .build();
+        given(tripRepository.findById(anyLong())).willReturn(Optional.of(trip));
+        given(tripRepository.save(any()))
+                .willReturn(Trip.builder()
+                        .id(1L)
+                        .title("타이틀입니다")
+                        .isPrivate(true)
+                        .description("설명입니다")
+                        .leader(member)
+                        .build());
+        //when
+        TripDto result = tripService.updateTrip(1L, form, member);
+        //then
+        verify(tripRepository, times(1)).save(any());
+        assertEquals("타이틀입니다", result.getTitle());
+        assertEquals("설명입니다", result.getDescription());
+    }
+
+    @Test
+    @DisplayName("여행 기록장 수정 실패 - 해당 여행 기록장 없음")
+    void updateTripTest_failWhenNotFoundTrip() {
+        //given
+        UpdateTripForm form = UpdateTripForm.builder()
+                .title("강릉 여행팟")
+                .description("강릉 여행을 5/13-5/20일 간다")
+                .isPrivate(false)
+                .build();
+        given(tripRepository.findById(anyLong())).willReturn(Optional.empty());
+        //when
+        CustomException exception = assertThrows(CustomException.class,
+                () -> tripService.updateTrip(1L, form, member));
+        //then
+        assertEquals(exception.getErrorCode(), ErrorCode.NOT_FOUND_TRIP);
+    }
+
+    @Test
+    @DisplayName("여행 기록장 수정 실패 - 해당 여행 기록장 없음")
+    void updateTripTest_failWhenNotAuthorityWriteTrip() {
+        //given
+        UpdateTripForm form = UpdateTripForm.builder()
+                .title("강릉 여행팟")
+                .description("강릉 여행을 5/13-5/20일 간다")
+                .isPrivate(false)
+                .build();
+        Member leader = Member.builder()
+                .id(2L)
+                .username("asdfg")
+                .nickname("이땡땡")
+                .password("1234567")
+                .profileUrl(null)
+                .phone("01011111112")
+                .build();
+
+        given(tripRepository.findById(anyLong()))
+                .willReturn(Optional.of(
+                        Trip.builder()
+                                .id(1L)
+                                .title("타이틀입니다")
+                                .isPrivate(true)
+                                .description("설명입니다")
+                                .leader(leader)
+                                .build()
+                ));
+        //when
+        CustomException exception = assertThrows(CustomException.class,
+                () -> tripService.updateTrip(1L, form, member));
+        //then
+        assertEquals(exception.getErrorCode(), ErrorCode.NOT_AUTHORITY_WRITE_TRIP);
+    }
+
+    @Test
+    @DisplayName("여행 기록장 참여 멤버 조회 성공 - 조회자가 리더인 경우")
+    void getTripParticipantsTest_successWhenReaderIsTripLeader() {
+        //given
+        Trip trip = Trip.builder()
+                .id(1L)
+                .title("임의의 타이틀")
+                .isPrivate(true)
+                .description("임의의 설명")
+                .leader(member)
+                .participants(List.of(
+                        Participant.builder()
+                                .member(member)
+                                .type(ParticipantType.ACCEPTED)
+                                .build(),
+                        Participant.builder()
+                                .member(participant1)
+                                .type(ParticipantType.PENDING)
+                                .build(),
+                        Participant.builder()
+                                .member(participant2)
+                                .type(ParticipantType.PENDING)
+                                .build()))
+                .build();
+        given(tripRepository.findById(anyLong())).willReturn(Optional.of(trip));
+        //when
+        List<ParticipantDto> result = tripService.getTripParticipants(1L, member);
+        //then
+        assertTrue(result.get(0).isReader());
+        assertTrue(result.get(0).isAccepted());
+        assertEquals(participant1.getNickname(), result.get(1).getNickname());
+        assertFalse(result.get(1).isReader());
+        assertFalse(result.get(1).isAccepted());
+    }
+
+    @Test
+    @DisplayName("여행 기록장 참여 멤버 조회 성공 - 조회자가 초대받은 사람인 경우")
+    void getTripParticipantsTest_successWhenReaderIsParticipants() {
+        //given
+        Trip trip = Trip.builder()
+                .id(1L)
+                .title("임의의 타이틀")
+                .isPrivate(true)
+                .description("임의의 설명")
+                .leader(member)
+                .participants(List.of(
+                        Participant.builder()
+                                .member(member)
+                                .type(ParticipantType.ACCEPTED)
+                                .build(),
+                        Participant.builder()
+                                .member(participant1)
+                                .type(ParticipantType.PENDING)
+                                .build(),
+                        Participant.builder()
+                                .member(participant2)
+                                .type(ParticipantType.PENDING)
+                                .build()))
+                .build();
+        given(tripRepository.findById(anyLong())).willReturn(Optional.of(trip));
+        //when
+        List<ParticipantDto> result = tripService.getTripParticipants(1L, participant1);
+        //then
+        assertFalse(result.get(0).isReader());
+        assertTrue(result.get(0).isAccepted());
+        assertNotEquals(participant1.getNickname(), result.get(1).getNickname());
+        assertTrue(result.get(1).isReader());
+        assertFalse(result.get(1).isAccepted());
+    }
+
+    @Test
+    @DisplayName("여행 기록장 참여 멤버 조회 성공 - 조회자가 참여자가 아니지만 해당 여행기록장이 모두 공개임")
+    void getTripParticipantsTest_successWhenTripIsPublic() {
+        //given
+        Member leader = Member.builder()
+                .id(4L)
+                .username("1234qwert")
+                .nickname("오땡땡")
+                .password("1234567")
+                .profileUrl(null)
+                .phone("01011111114")
+                .build();
+
+        Trip trip = Trip.builder()
+                .id(1L)
+                .title("임의의 타이틀")
+                .isPrivate(false)
+                .description("임의의 설명")
+                .leader(leader)
+                .participants(List.of(
+                        Participant.builder()
+                                .member(leader)
+                                .type(ParticipantType.ACCEPTED)
+                                .build(),
+                        Participant.builder()
+                                .member(participant1)
+                                .type(ParticipantType.PENDING)
+                                .build(),
+                        Participant.builder()
+                                .member(participant2)
+                                .type(ParticipantType.PENDING)
+                                .build()))
+                .build();
+        given(tripRepository.findById(anyLong())).willReturn(Optional.of(trip));
+        //when
+        List<ParticipantDto> result = tripService.getTripParticipants(1L, member);
+        //then
+        assertFalse(result.get(0).isReader());
+        assertTrue(result.get(0).isAccepted());
+        assertEquals(participant1.getNickname(), result.get(1).getNickname());
+        assertFalse(result.get(1).isReader());
+        assertFalse(result.get(1).isAccepted());
+    }
+
+    @Test
+    @DisplayName("여행 기록장 참여 멤버 조회 성공 - 조회자가 참여자가 아니고 해당 여행 기록장이 비밀임")
+    void getTripParticipantsTest_failWhenNotAuthorityReadTrip() {
+        //given
+        Member leader = Member.builder()
+                .id(4L)
+                .username("1234qwert")
+                .nickname("오땡땡")
+                .password("1234567")
+                .profileUrl(null)
+                .phone("01011111114")
+                .build();
+
+        Trip trip = Trip.builder()
+                .id(1L)
+                .title("임의의 타이틀")
+                .isPrivate(true)
+                .description("임의의 설명")
+                .leader(leader)
+                .participants(List.of(
+                        Participant.builder()
+                                .member(leader)
+                                .type(ParticipantType.ACCEPTED)
+                                .build(),
+                        Participant.builder()
+                                .member(participant1)
+                                .type(ParticipantType.PENDING)
+                                .build(),
+                        Participant.builder()
+                                .member(participant2)
+                                .type(ParticipantType.PENDING)
+                                .build()))
+                .build();
+        given(tripRepository.findById(anyLong())).willReturn(Optional.of(trip));
+        //when
+        CustomException exception = assertThrows(CustomException.class,
+                () -> tripService.getTripParticipants(1L, member));
+        //then
+        assertEquals(exception.getErrorCode(), ErrorCode.NOT_AUTHORITY_READ_TRIP);
+    }
+
+}


### PR DESCRIPTION
## What is this PR? 🔎
여행 기록장을 만들고 수정하는 기능입니다.
유저 검색 기능을 위해 회원가입시 `event listener` 를 활용해 유저 정보를 `elastic search`에 저장합니다.
여행 기록장에 유저가 초대되면 해당 여행 기록장 아이디를 `elastic search` 에 업데이트 합니다.

## Changes ✅
- 여행 기록장을 만드는 기능
- 여행 기록장을 수정하는 기능
- 여행 기록장의 참여 멤버를 확인하는 기능
- 회원가입시 `elastic search` 에 유저의 기본 정보 저장
- 여행 기록장에 초대된 멤버에 es document에 해당 여행 기록장 id 업데이트

## To Reviewers 🙇‍♀️ 
-  `AsyncConfig` 부분 설정이 괜찮은지 한번 살펴봐주시면 감사하겠습니다.
-  `MemberDocument ` 에 Nested Array를 사용하기 위해 내부에 static class 를 추가했는데, 이 부분이 괜찮은 방법인지 모르겠습니다. `List<Long> trips` 로 할 경우 **object mapping for [] tried to parse field [null] as object, but found a concrete value** 에러가 발생해서 부득이 하게 이 방법으로 진행했습니다. 더 좋은 방향이 있으시면 말씀해주세요.

## 기타 😶
- docker로 elastic search 설치
`docker pull docker.elastic.co/elasticsearch/elasticsearch-oss:7.10.2-arm64 `  
`docker run -p 9200:9200 -p 9300:9300 --name elasticsearch -e "discovery.type=single-node" docker.elastic.co/elasticsearch/elasticsearch-oss:7.10.2-arm64`

- docker로 kibana 설치
`docker pull docker.elastic.co/kibana/kibana-oss:7.10.2`
`docker run --link elasticsearch:elasticsearch --platform linux/amd64 -p 5601:5601 docker.elastic.co/kibana/kibana-oss:7.10.2`