### PR TITLE
[005-exception] 예외 처리 개선

### DIFF
--- a/src/main/java/com/trip/diary/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/trip/diary/exception/GlobalExceptionHandler.java
@@ -9,15 +9,24 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 @Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler {
-    @ExceptionHandler({CustomException.class})
-    public ResponseEntity<ExceptionResponse> handleCustomException(CustomException e) {
-        log.warn("api exception : {}", e.getErrorCode());
-        return ResponseEntity.badRequest().body(new ExceptionResponse(e.getErrorCode().name(), e.getMessage()));
+    @ExceptionHandler({MemberException.class})
+    public ResponseEntity<ExceptionResponse> handleMemberException(MemberException e) {
+        log.warn("member exception : {}", e.getErrorCode());
+        return ResponseEntity.status(e.getErrorCode().getHttpStatus())
+                .body(new ExceptionResponse(e.getErrorCode().name(), e.getMessage()));
+    }
+
+    @ExceptionHandler({TripException.class})
+    public ResponseEntity<ExceptionResponse> handleTripException(TripException e) {
+        log.warn("trip exception : {}", e.getErrorCode());
+        return ResponseEntity.status(e.getErrorCode().getHttpStatus())
+                .body(new ExceptionResponse(e.getErrorCode().name(), e.getMessage()));
     }
 
     @ExceptionHandler({Exception.class})
-    public ResponseEntity<ExceptionResponse> handleCustomException(Exception e) {
+    public ResponseEntity<ExceptionResponse> handleException(Exception e) {
         log.warn("internal error : {}", e.getMessage());
-        return ResponseEntity.badRequest().body(new ExceptionResponse(HttpStatus.INTERNAL_SERVER_ERROR.name(), e.getMessage()));
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(new ExceptionResponse(HttpStatus.INTERNAL_SERVER_ERROR.name(), e.getMessage()));
     }
 }

--- a/src/main/java/com/trip/diary/exception/MemberException.java
+++ b/src/main/java/com/trip/diary/exception/MemberException.java
@@ -1,0 +1,13 @@
+package com.trip.diary.exception;
+
+import lombok.Getter;
+
+@Getter
+public class MemberException extends RuntimeException {
+    private final ErrorCode errorCode;
+
+    public MemberException(ErrorCode errorCode) {
+        super(errorCode.getDetail());
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/com/trip/diary/exception/TripException.java
+++ b/src/main/java/com/trip/diary/exception/TripException.java
@@ -1,0 +1,13 @@
+package com.trip.diary.exception;
+
+import lombok.Getter;
+
+@Getter
+public class TripException extends RuntimeException {
+    private final ErrorCode errorCode;
+
+    public TripException(ErrorCode errorCode) {
+        super(errorCode.getDetail());
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/com/trip/diary/service/AuthService.java
+++ b/src/main/java/com/trip/diary/service/AuthService.java
@@ -5,15 +5,13 @@ import com.trip.diary.domain.repository.MemberRepository;
 import com.trip.diary.dto.SignInForm;
 import com.trip.diary.dto.SignUpForm;
 import com.trip.diary.dto.TokenDto;
-import com.trip.diary.elasticsearch.model.MemberDocument;
 import com.trip.diary.event.dto.MemberRegisterEvent;
-import com.trip.diary.exception.CustomException;
 import com.trip.diary.exception.ErrorCode;
+import com.trip.diary.exception.MemberException;
 import com.trip.diary.security.TokenProvider;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.ApplicationEventPublisher;
-import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -36,11 +34,11 @@ public class AuthService {
     @Transactional
     public void register(SignUpForm form) {
         if (memberRepository.existsByUsername(form.getUsername())) {
-            throw new CustomException(ID_ALREADY_USED);
+            throw new MemberException(ID_ALREADY_USED);
         }
 
         if (memberRepository.existsByPhone(form.getPhone())) {
-            throw new CustomException(MOBILE_ALREADY_REGISTERED);
+            throw new MemberException(MOBILE_ALREADY_REGISTERED);
         }
 
         form.setPassword(passwordEncoder.encode(form.getPassword()));
@@ -59,10 +57,10 @@ public class AuthService {
 
     public TokenDto authenticate(SignInForm form) {
         Member member = memberRepository.findByUsername(form.getUsername())
-                .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_MEMBER));
+                .orElseThrow(() -> new MemberException(ErrorCode.NOT_FOUND_MEMBER));
 
         if (!passwordEncoder.matches(form.getPassword(), member.getPassword())) {
-            throw new CustomException(ErrorCode.PASSWORD_UNMATCHED);
+            throw new MemberException(ErrorCode.PASSWORD_UNMATCHED);
         }
 
         return new TokenDto(tokenProvider.generateToken(form.getUsername()));

--- a/src/main/java/com/trip/diary/service/TripService.java
+++ b/src/main/java/com/trip/diary/service/TripService.java
@@ -8,11 +8,10 @@ import com.trip.diary.domain.repository.ParticipantRepository;
 import com.trip.diary.domain.repository.TripRepository;
 import com.trip.diary.dto.*;
 import com.trip.diary.event.dto.TripInviteEvent;
-import com.trip.diary.exception.CustomException;
 import com.trip.diary.exception.ErrorCode;
+import com.trip.diary.exception.TripException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
-import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -74,12 +73,12 @@ public class TripService {
     @Transactional
     public List<ParticipantDto> getTripParticipants(Long tripId, Member member) {
         Trip trip = tripRepository.findById(tripId)
-                .orElseThrow(() -> new CustomException(NOT_FOUND_TRIP));
+                .orElseThrow(() -> new TripException(NOT_FOUND_TRIP));
 
         List<Participant> participants = trip.getParticipants();
 
         if (trip.isPrivate() && !isMemberTripParticipants(participants, member.getId())) {
-            throw new CustomException(ErrorCode.NOT_AUTHORITY_READ_TRIP);
+            throw new TripException(ErrorCode.NOT_AUTHORITY_READ_TRIP);
         }
 
         return participants
@@ -96,10 +95,10 @@ public class TripService {
 
     public TripDto updateTrip(Long tripId, UpdateTripForm form, Member member) {
         Trip trip = tripRepository.findById(tripId)
-                .orElseThrow(() -> new CustomException(NOT_FOUND_TRIP));
+                .orElseThrow(() -> new TripException(NOT_FOUND_TRIP));
 
         if (!Objects.equals(trip.getLeader().getId(), member.getId())) {
-            throw new CustomException(NOT_AUTHORITY_WRITE_TRIP);
+            throw new TripException(NOT_AUTHORITY_WRITE_TRIP);
         }
 
         trip.update(form);

--- a/src/test/java/com/trip/diary/service/AuthServiceTest.java
+++ b/src/test/java/com/trip/diary/service/AuthServiceTest.java
@@ -5,8 +5,8 @@ import com.trip.diary.domain.repository.MemberRepository;
 import com.trip.diary.dto.SignInForm;
 import com.trip.diary.dto.SignUpForm;
 import com.trip.diary.dto.TokenDto;
-import com.trip.diary.exception.CustomException;
 import com.trip.diary.exception.ErrorCode;
+import com.trip.diary.exception.MemberException;
 import com.trip.diary.security.TokenProvider;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -87,7 +87,7 @@ class AuthServiceTest {
                 .build();
         given(memberRepository.existsByUsername(anyString())).willReturn(true);
         //when
-        CustomException exception = assertThrows(CustomException.class,
+        MemberException exception = assertThrows(MemberException.class,
                 () -> authService.register(form));
         //then
         assertEquals(exception.getErrorCode(), ErrorCode.ID_ALREADY_USED);
@@ -106,7 +106,7 @@ class AuthServiceTest {
         given(memberRepository.existsByUsername(anyString())).willReturn(false);
         given(memberRepository.existsByPhone(anyString())).willReturn(true);
         //when
-        CustomException exception = assertThrows(CustomException.class,
+        MemberException exception = assertThrows(MemberException.class,
                 () -> authService.register(form));
         //then
         assertEquals(exception.getErrorCode(), ErrorCode.MOBILE_ALREADY_REGISTERED);
@@ -139,7 +139,7 @@ class AuthServiceTest {
                 .build();
         given(memberRepository.findByUsername(anyString())).willReturn(Optional.empty());
         //when
-        CustomException exception = assertThrows(CustomException.class,
+        MemberException exception = assertThrows(MemberException.class,
                 () -> authService.authenticate(form));
         //then
         assertEquals(ErrorCode.NOT_FOUND_MEMBER, exception.getErrorCode());
@@ -156,7 +156,7 @@ class AuthServiceTest {
         given(memberRepository.findByUsername(anyString())).willReturn(Optional.of(member));
         given(passwordEncoder.matches(any(), anyString())).willReturn(false);
         //when
-        CustomException exception = assertThrows(CustomException.class,
+        MemberException exception = assertThrows(MemberException.class,
                 () -> authService.authenticate(form));
         //then
         assertEquals(ErrorCode.PASSWORD_UNMATCHED, exception.getErrorCode());

--- a/src/test/java/com/trip/diary/service/TripServiceTest.java
+++ b/src/test/java/com/trip/diary/service/TripServiceTest.java
@@ -8,8 +8,8 @@ import com.trip.diary.domain.repository.ParticipantRepository;
 import com.trip.diary.domain.repository.TripRepository;
 import com.trip.diary.domain.type.ParticipantType;
 import com.trip.diary.dto.*;
-import com.trip.diary.exception.CustomException;
 import com.trip.diary.exception.ErrorCode;
+import com.trip.diary.exception.TripException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -193,7 +193,7 @@ class TripServiceTest {
                 .build();
         given(tripRepository.findById(anyLong())).willReturn(Optional.empty());
         //when
-        CustomException exception = assertThrows(CustomException.class,
+        TripException exception = assertThrows(TripException.class,
                 () -> tripService.updateTrip(1L, form, member));
         //then
         assertEquals(exception.getErrorCode(), ErrorCode.NOT_FOUND_TRIP);
@@ -228,7 +228,7 @@ class TripServiceTest {
                                 .build()
                 ));
         //when
-        CustomException exception = assertThrows(CustomException.class,
+        TripException exception = assertThrows(TripException.class,
                 () -> tripService.updateTrip(1L, form, member));
         //then
         assertEquals(exception.getErrorCode(), ErrorCode.NOT_AUTHORITY_WRITE_TRIP);
@@ -383,7 +383,7 @@ class TripServiceTest {
                 .build();
         given(tripRepository.findById(anyLong())).willReturn(Optional.of(trip));
         //when
-        CustomException exception = assertThrows(CustomException.class,
+        TripException exception = assertThrows(TripException.class,
                 () -> tripService.getTripParticipants(1L, member));
         //then
         assertEquals(exception.getErrorCode(), ErrorCode.NOT_AUTHORITY_READ_TRIP);


### PR DESCRIPTION
## What is this PR? 🔎
예외 처리에 대해 네이밍이 추상적이고, HttpStatus 와 ExceptionResponse 가 일관적이지 않다는 문제가 있어 개선함

## Changes ✅
- `CustomException` 이라는 네이밍을 각각의 `Domain + Exception` 으로 수정함
- Exception에 대한 응답에 `ResponseEntity.status()` 를 활용해 응답값과 정의한 에러 코드 사이의 일관성 확보

## To Reviewers 🙇‍♀️ 
