### PR TITLE
[020-cache] 여행 기록장 권한 조회 메서드 캐싱 처리

### DIFF
--- a/src/main/java/com/trip/diary/config/CacheConfig.java
+++ b/src/main/java/com/trip/diary/config/CacheConfig.java
@@ -1,0 +1,37 @@
+package com.trip.diary.config;
+
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+import java.time.Duration;
+
+@Configuration
+@EnableCaching
+public class CacheConfig {
+    @Bean
+    public CacheManager cacheManager(RedisConnectionFactory redisConnectionFactory) {
+        return RedisCacheManager.RedisCacheManagerBuilder
+                .fromConnectionFactory(redisConnectionFactory)
+                .cacheDefaults(
+                        RedisCacheConfiguration
+                                .defaultCacheConfig()
+                                .disableCachingNullValues()
+                                .entryTtl(Duration.ofSeconds(3600))
+                                .serializeKeysWith(
+                                        RedisSerializationContext.SerializationPair
+                                                .fromSerializer(new StringRedisSerializer()))
+                                .serializeValuesWith(
+                                        RedisSerializationContext.
+                                                SerializationPair
+                                                .fromSerializer(new GenericJackson2JsonRedisSerializer())))
+                .build();
+    }
+}

--- a/src/main/java/com/trip/diary/config/RedisConfig.java
+++ b/src/main/java/com/trip/diary/config/RedisConfig.java
@@ -1,14 +1,10 @@
 package com.trip.diary.config;
 
-import org.springframework.cache.CacheManager;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.data.redis.cache.RedisCacheConfiguration;
-import org.springframework.data.redis.cache.RedisCacheManager;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
-import org.springframework.data.redis.serializer.RedisSerializationContext;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 @Configuration
@@ -20,23 +16,5 @@ public class RedisConfig {
         redisTemplate.setKeySerializer(new StringRedisSerializer());
         redisTemplate.setValueSerializer(new GenericJackson2JsonRedisSerializer());
         return redisTemplate;
-    }
-
-    @Bean
-    public CacheManager cacheManager(RedisConnectionFactory redisConnectionFactory) {
-        return RedisCacheManager.RedisCacheManagerBuilder
-                .fromConnectionFactory(redisConnectionFactory)
-                .cacheDefaults(
-                        RedisCacheConfiguration
-                                .defaultCacheConfig()
-                                .disableCachingNullValues()
-                                .serializeKeysWith(
-                                        RedisSerializationContext.SerializationPair
-                                                .fromSerializer(new StringRedisSerializer()))
-                                .serializeValuesWith(
-                                        RedisSerializationContext.
-                                                SerializationPair
-                                                .fromSerializer(new GenericJackson2JsonRedisSerializer())))
-                .build();
     }
 }

--- a/src/main/java/com/trip/diary/domain/repository/ParticipantRepository.java
+++ b/src/main/java/com/trip/diary/domain/repository/ParticipantRepository.java
@@ -4,6 +4,7 @@ import com.trip.diary.domain.constants.ParticipantType;
 import com.trip.diary.domain.model.Member;
 import com.trip.diary.domain.model.Participant;
 import com.trip.diary.domain.model.Trip;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -14,6 +15,7 @@ import java.util.Optional;
 public interface ParticipantRepository extends JpaRepository<Participant, Long> {
     boolean existsByTripAndMember(Trip trip, Member member);
 
+    @Cacheable(key = "{#trip.id, #member.id}", value = "TripAuthorities")
     boolean existsByTripAndMemberAndType(Trip trip, Member member, ParticipantType type);
 
     Optional<Participant> findByTripAndMember_Id(Trip trip, Long memberId);

--- a/src/test/java/com/trip/diary/domain/repository/ParticipantRepositoryTest.java
+++ b/src/test/java/com/trip/diary/domain/repository/ParticipantRepositoryTest.java
@@ -1,0 +1,50 @@
+package com.trip.diary.domain.repository;
+
+import com.trip.diary.TripApplication;
+import com.trip.diary.domain.constants.ParticipantType;
+import com.trip.diary.domain.model.Member;
+import com.trip.diary.domain.model.Trip;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cache.CacheManager;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.util.List;
+import java.util.Optional;
+
+import static java.util.Optional.ofNullable;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(classes = TripApplication.class)
+class ParticipantRepositoryTest {
+    @Autowired
+    CacheManager cacheManager;
+
+    @Autowired
+    ParticipantRepository participantRepository;
+
+    Member member = Member.builder()
+            .id(1L)
+            .build();
+
+    Trip trip = Trip.builder()
+            .id(1L)
+            .build();
+
+    private Optional<Boolean> getCachedData(Member member, Trip trip) {
+        return ofNullable(cacheManager.getCache("TripAuthorities"))
+                .map(cache -> cache.get(List.of(trip.getId(), member.getId()), Boolean.class));
+    }
+
+    @Test
+    @DisplayName("여행 기록장 참여 여부 캐싱 성공")
+    void cachedTest_success() {
+        boolean result = participantRepository.existsByTripAndMemberAndType(trip, member, ParticipantType.ACCEPTED);
+
+        assertEquals(result, getCachedData(member, trip).get());
+    }
+}

--- a/src/test/java/com/trip/diary/service/ParticipantServiceTest.java
+++ b/src/test/java/com/trip/diary/service/ParticipantServiceTest.java
@@ -17,6 +17,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
 
 import java.util.List;
 import java.util.Optional;
@@ -35,6 +36,9 @@ class ParticipantServiceTest {
 
     @Mock
     private ParticipantRepository participantRepository;
+
+    @Mock
+    private ApplicationEventPublisher applicationEventPublisher;
 
     @InjectMocks
     private ParticipantService participantService;


### PR DESCRIPTION
## What is this PR? 🔎
여행 기록장 권한 조회에 활용되는 `existsByTripAndMemberAndType` 을 캐싱 처리했습니다.
멤버 강퇴 이벤트 발생시 캐시가 사라지도록 구현했고, 캐시 유효 시간은 한 시간으로 설정해뒀습니다.

## Changes ✅
- 여행 기록장 권한 조회 메서드 캐싱 처리
- 캐시 유효 시간 한 시간으로 설정

## To Reviewers 🙇‍♀️ 
