### PR TITLE
[022-comment] 댓글 삭제 로직 수정

### DIFF
--- a/src/main/java/com/trip/diary/domain/model/Comment.java
+++ b/src/main/java/com/trip/diary/domain/model/Comment.java
@@ -43,8 +43,6 @@ public class Comment extends BaseEntity {
     }
 
     public void delete() {
-        this.content = "삭제된 댓글입니다.";
-        this.member = Member.builder().id(UNIDENTIFIED_MEMBER_ID).build();
         this.deletedAt = LocalDateTime.now();
     }
 }

--- a/src/main/java/com/trip/diary/dto/CommentDto.java
+++ b/src/main/java/com/trip/diary/dto/CommentDto.java
@@ -9,24 +9,22 @@ import lombok.NoArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 @AllArgsConstructor
 @NoArgsConstructor
 @Builder
 @Slf4j
 @Getter
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class CommentDto {
     private Long id;
     private String content;
-    @JsonInclude(JsonInclude.Include.NON_NULL)
     private Integer countOfComments;
-    private long countOfLikes;
+    private Long countOfLikes;
     private Long authorId;
     private String authorNickname;
     private String authorProfilePath;
     private Boolean isReader;
-    @JsonInclude(JsonInclude.Include.NON_NULL)
     private Boolean isReaderLiked;
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private List<CommentDto> reComments;
@@ -61,13 +59,22 @@ public class CommentDto {
                 .id(comment.getId())
                 .content(comment.getContent())
                 .countOfLikes(countOfLikes)
-                .countOfComments(comment.getReComments().size())
+                .countOfComments(reCommentDtos.size())
                 .reComments(reCommentDtos)
                 .authorId(comment.getMember().getId())
                 .authorNickname(comment.getMember().getNickname())
                 .authorProfilePath(comment.getMember().getProfilePath())
                 .isReader(comment.getMember().isReader(readerId))
                 .isReaderLiked(isReaderLiked)
+                .build();
+    }
+
+    public static CommentDto blind(List<CommentDto> reCommentDtos) {
+        return CommentDto.builder()
+                .authorNickname("알수없음")
+                .content("삭제된 댓글입니다.")
+                .reComments(reCommentDtos)
+                .countOfComments(reCommentDtos.size())
                 .build();
     }
 }

--- a/src/main/java/com/trip/diary/service/CommentService.java
+++ b/src/main/java/com/trip/diary/service/CommentService.java
@@ -94,12 +94,18 @@ public class CommentService {
         validationMemberHaveReadAuthority(post.getTrip(), member);
 
         return commentRepository.findByPostAndParentCommentIsNull(post).stream()
-                .map(comment -> CommentDto.of(comment,
-                        getReCommentDto(comment.getReComments(), member.getId()),
-                        member.getId(),
+                .map(comment -> getCommentDto(comment, member.getId()))
+                .collect(Collectors.toList());
+    }
+
+    private CommentDto getCommentDto(Comment comment, Long readerId) {
+        return Objects.isNull(comment.getDeletedAt()) ?
+                CommentDto.of(comment,
+                        getReCommentDto(comment.getReComments(), readerId),
+                        readerId,
                         commentLikeRedisRepository.countByCommentId(comment.getId()),
-                        commentLikeRedisRepository.existsByCommentIdAndUserId(comment.getId(), member.getId())
-                )).collect(Collectors.toList());
+                        commentLikeRedisRepository.existsByCommentIdAndUserId(comment.getId(), readerId))
+                : CommentDto.blind(getReCommentDto(comment.getReComments(), readerId));
     }
 
     private List<CommentDto> getReCommentDto(List<Comment> reComments, Long readerId) {

--- a/src/test/java/com/trip/diary/service/CommentServiceTest.java
+++ b/src/test/java/com/trip/diary/service/CommentServiceTest.java
@@ -456,8 +456,6 @@ class CommentServiceTest {
         ArgumentCaptor<Comment> captor = ArgumentCaptor.forClass(Comment.class);
         //then
         verify(commentRepository, times(1)).save(captor.capture());
-        assertEquals("삭제된 댓글입니다.", captor.getValue().getContent());
-        assertEquals(-1L, captor.getValue().getMember().getId());
         assertNotNull(captor.getValue().getDeletedAt());
     }
 


### PR DESCRIPTION
## What is this PR? 🔎
기존의 댓글 삭제 로직이 원본 데이터를 훼손하는 이슈가 있어, deletedAt 컬럼 마킹만으로 변경했습니다.

## Changes ✅
- 댓글 삭제 로직을 deletedAt 컬럼 마킹만으로 수정
- dto에 블라인드 로직 추가

## To Reviewers 🙇‍♀️ 
