### PR TITLE
[025-trip-search] 여행 기록장을 검색하는 기능

### DIFF
--- a/src/main/java/com/trip/diary/controller/TripSearchController.java
+++ b/src/main/java/com/trip/diary/controller/TripSearchController.java
@@ -33,4 +33,11 @@ public class TripSearchController {
                                                            @AuthenticationPrincipal MemberPrincipal principal) {
         return ResponseEntity.ok(tripSearchService.searchByLocation(page, keyword, principal.getMember()));
     }
+
+    @GetMapping("/bookmarks/search")
+    private ResponseEntity<Page<TripDto>> searchByKeywordOrderByBookmark(@RequestParam int page,
+                                                          @RequestParam String keyword,
+                                                          @AuthenticationPrincipal MemberPrincipal principal) {
+        return ResponseEntity.ok(tripSearchService.searchByKeywordOrderByBookmark(page, keyword, principal.getMember()));
+    }
 }

--- a/src/main/java/com/trip/diary/controller/TripSearchController.java
+++ b/src/main/java/com/trip/diary/controller/TripSearchController.java
@@ -36,8 +36,8 @@ public class TripSearchController {
 
     @GetMapping("/bookmarks/search")
     private ResponseEntity<Page<TripDto>> searchByKeywordOrderByBookmark(@RequestParam int page,
-                                                          @RequestParam String keyword,
-                                                          @AuthenticationPrincipal MemberPrincipal principal) {
+                                                                         @RequestParam String keyword,
+                                                                         @AuthenticationPrincipal MemberPrincipal principal) {
         return ResponseEntity.ok(tripSearchService.searchByKeywordOrderByBookmark(page, keyword, principal.getMember()));
     }
 }

--- a/src/main/java/com/trip/diary/controller/TripSearchController.java
+++ b/src/main/java/com/trip/diary/controller/TripSearchController.java
@@ -1,0 +1,36 @@
+package com.trip.diary.controller;
+
+import com.trip.diary.dto.TripDto;
+import com.trip.diary.security.MemberPrincipal;
+import com.trip.diary.service.TripSearchService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@Slf4j
+@RequiredArgsConstructor
+@RequestMapping("/trips")
+public class TripSearchController {
+    private final TripSearchService tripSearchService;
+
+    @GetMapping("/search")
+    private ResponseEntity<Page<TripDto>> search(@RequestParam int page,
+                                                 @RequestParam String keyword,
+                                                 @AuthenticationPrincipal MemberPrincipal principal) {
+        return ResponseEntity.ok(tripSearchService.search(page, keyword, principal.getMember()));
+    }
+
+    @GetMapping("/locations/search")
+    private ResponseEntity<Page<TripDto>> searchByLocation(@RequestParam int page,
+                                                           @RequestParam String keyword,
+                                                           @AuthenticationPrincipal MemberPrincipal principal) {
+        return ResponseEntity.ok(tripSearchService.searchByLocation(page, keyword, principal.getMember()));
+    }
+}

--- a/src/main/java/com/trip/diary/domain/constants/Constants.java
+++ b/src/main/java/com/trip/diary/domain/constants/Constants.java
@@ -2,4 +2,5 @@ package com.trip.diary.domain.constants;
 
 public class Constants {
     public static final int BOOKMARK_PAGE_SIZE = 5;
+    public static final int SEARCH_PAGE_SIZE = 5;
 }

--- a/src/main/java/com/trip/diary/domain/repository/BookmarkRepository.java
+++ b/src/main/java/com/trip/diary/domain/repository/BookmarkRepository.java
@@ -15,4 +15,6 @@ public interface BookmarkRepository extends JpaRepository<Bookmark, Long> {
     Optional<Bookmark> findByTripAndMember(Trip trip, Member member);
 
     Slice<Bookmark> findByMember(Member member, Pageable pageable);
+
+    boolean existsByTrip_IdAndMember(Long tripId, Member member);
 }

--- a/src/main/java/com/trip/diary/domain/repository/LocationRepositoryCustom.java
+++ b/src/main/java/com/trip/diary/domain/repository/LocationRepositoryCustom.java
@@ -1,0 +1,22 @@
+package com.trip.diary.domain.repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+import static com.trip.diary.domain.model.QLocation.location;
+
+@Repository
+@RequiredArgsConstructor
+public class LocationRepositoryCustom {
+    private final JPAQueryFactory jpaQueryFactory;
+
+    public List<String> findLocationNameByTripId(Long tripId) {
+        return jpaQueryFactory.select(location.name)
+                .from(location)
+                .where(location.trip.id.eq(tripId))
+                .fetch();
+    }
+}

--- a/src/main/java/com/trip/diary/domain/repository/TripRepositoryCustom.java
+++ b/src/main/java/com/trip/diary/domain/repository/TripRepositoryCustom.java
@@ -35,8 +35,7 @@ public class TripRepositoryCustom {
                 .from(bookmark)
                 .leftJoin(bookmark.trip, trip)
                 .where(
-                        (tripDescriptionContains(keyword).or(triTitleContains(keyword)))
-                                .and(isTripPublic())
+                        isTripPublic().andAnyOf(tripDescriptionContains(keyword), triTitleContains(keyword))
                 )
                 .groupBy(trip.id)
                 .orderBy(aliasCount.desc())
@@ -47,8 +46,7 @@ public class TripRepositoryCustom {
         JPAQuery<Bookmark> countQuery = jpaQueryFactory.selectFrom(bookmark)
                 .leftJoin(bookmark.trip, trip)
                 .where(
-                        (tripDescriptionContains(keyword).or(triTitleContains(keyword)))
-                                .and(isTripPublic())
+                        isTripPublic().andAnyOf(tripDescriptionContains(keyword), triTitleContains(keyword))
                 );
 
         return PageableExecutionUtils.getPage(content, pageable, () -> countQuery.fetch().size());
@@ -65,7 +63,7 @@ public class TripRepositoryCustom {
     }
 
     private BooleanExpression isTripPublic() {
-        return trip.isPrivate.eq(false);
+        return trip.isPrivate.isFalse();
     }
 
 

--- a/src/main/java/com/trip/diary/domain/repository/TripRepositoryCustom.java
+++ b/src/main/java/com/trip/diary/domain/repository/TripRepositoryCustom.java
@@ -1,0 +1,72 @@
+package com.trip.diary.domain.repository;
+
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.core.types.dsl.NumberPath;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.trip.diary.domain.model.Bookmark;
+import com.trip.diary.dto.TripBookmarkDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.support.PageableExecutionUtils;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+import static com.trip.diary.domain.model.QBookmark.bookmark;
+import static com.trip.diary.domain.model.QTrip.trip;
+import static org.springframework.util.StringUtils.hasText;
+
+@Repository
+@RequiredArgsConstructor
+public class TripRepositoryCustom {
+    private final JPAQueryFactory jpaQueryFactory;
+
+    public Page<TripBookmarkDto> findByKeywordContainsOrderByBookmark(String keyword, Pageable pageable) {
+        NumberPath<Long> aliasCount = Expressions.numberPath(Long.class, "countOfBookmarked");
+        List<TripBookmarkDto> content = jpaQueryFactory.select(
+                        Projections.constructor(TripBookmarkDto.class,
+                                trip.id, trip.isPrivate,
+                                trip.title, trip.description,
+                                trip.id.count().as(aliasCount)))
+                .from(bookmark)
+                .leftJoin(bookmark.trip, trip)
+                .where(
+                        (tripDescriptionContains(keyword).or(triTitleContains(keyword)))
+                                .and(isTripPublic())
+                )
+                .groupBy(trip.id)
+                .orderBy(aliasCount.desc())
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        JPAQuery<Bookmark> countQuery = jpaQueryFactory.selectFrom(bookmark)
+                .leftJoin(bookmark.trip, trip)
+                .where(
+                        (tripDescriptionContains(keyword).or(triTitleContains(keyword)))
+                                .and(isTripPublic())
+                );
+
+        return PageableExecutionUtils.getPage(content, pageable, () -> countQuery.fetch().size());
+
+
+    }
+
+    private BooleanExpression tripDescriptionContains(String keyword) {
+        return hasText(keyword) ? trip.description.containsIgnoreCase(keyword) : null;
+    }
+
+    private BooleanExpression triTitleContains(String keyword) {
+        return hasText(keyword) ? trip.title.containsIgnoreCase(keyword) : null;
+    }
+
+    private BooleanExpression isTripPublic() {
+        return trip.isPrivate.eq(false);
+    }
+
+
+}

--- a/src/main/java/com/trip/diary/dto/TripBookmarkDto.java
+++ b/src/main/java/com/trip/diary/dto/TripBookmarkDto.java
@@ -1,0 +1,24 @@
+package com.trip.diary.dto;
+
+import com.querydsl.core.annotations.QueryProjection;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class TripBookmarkDto {
+    private Long tripId;
+    private boolean isPrivate;
+    private String title;
+    private String description;
+    private Long countOfBookmarked;
+
+    @QueryProjection
+    public TripBookmarkDto(Long tripId, boolean isPrivate, String title, String description, Long countOfBookmarked) {
+        this.tripId = tripId;
+        this.isPrivate = isPrivate;
+        this.title = title;
+        this.description = description;
+        this.countOfBookmarked = countOfBookmarked;
+    }
+}

--- a/src/main/java/com/trip/diary/dto/TripDto.java
+++ b/src/main/java/com/trip/diary/dto/TripDto.java
@@ -2,8 +2,10 @@ package com.trip.diary.dto;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.trip.diary.domain.constants.ParticipantType;
+import com.trip.diary.domain.model.Bookmark;
 import com.trip.diary.domain.model.Location;
 import com.trip.diary.domain.model.Trip;
+import com.trip.diary.elasticsearch.model.TripDocument;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -20,6 +22,8 @@ public class TripDto {
     private Long id;
     private String title;
     private String description;
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private Boolean isBookmarked;
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private List<ParticipantDto> participants;
     private List<String> locations;
@@ -36,6 +40,29 @@ public class TripDto {
                         .collect(Collectors.toList()))
                 .locations(trip.getLocations().stream()
                         .map(Location::getName).collect(Collectors.toList()))
+                .build();
+    }
+
+    public static TripDto of(Bookmark bookmark) {
+        return TripDto.builder()
+                .id(bookmark.getTrip().getId())
+                .title(bookmark.getTrip().getTitle())
+                .description(bookmark.getTrip().getDescription())
+                .isBookmarked(true)
+                .locations(bookmark.getTrip().getLocations().stream()
+                        .map(Location::getName).collect(Collectors.toList()))
+                .build();
+    }
+
+    public static TripDto of(TripDocument document, boolean isBookmarked){
+        return TripDto.builder()
+                .id(document.getId())
+                .title(document.getTitle())
+                .description(document.getDescription())
+                .isBookmarked(isBookmarked)
+                .locations(document.getLocations().stream()
+                        .map(TripDocument.Location::getName)
+                        .collect(Collectors.toList()))
                 .build();
     }
 }

--- a/src/main/java/com/trip/diary/dto/TripDto.java
+++ b/src/main/java/com/trip/diary/dto/TripDto.java
@@ -12,6 +12,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 @AllArgsConstructor
@@ -26,7 +27,7 @@ public class TripDto {
     private Boolean isBookmarked;
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private List<ParticipantDto> participants;
-    private List<String> locations;
+    private Set<String> locations;
 
     public static TripDto of(Trip trip) {
         return TripDto.builder()
@@ -39,7 +40,7 @@ public class TripDto {
                                         participant.getMember().getProfilePath()))
                         .collect(Collectors.toList()))
                 .locations(trip.getLocations().stream()
-                        .map(Location::getName).collect(Collectors.toList()))
+                        .map(Location::getName).collect(Collectors.toSet()))
                 .build();
     }
 
@@ -50,11 +51,11 @@ public class TripDto {
                 .description(bookmark.getTrip().getDescription())
                 .isBookmarked(true)
                 .locations(bookmark.getTrip().getLocations().stream()
-                        .map(Location::getName).collect(Collectors.toList()))
+                        .map(Location::getName).collect(Collectors.toSet()))
                 .build();
     }
 
-    public static TripDto of(TripDocument document, boolean isBookmarked){
+    public static TripDto of(TripDocument document, boolean isBookmarked) {
         return TripDto.builder()
                 .id(document.getId())
                 .title(document.getTitle())
@@ -62,7 +63,7 @@ public class TripDto {
                 .isBookmarked(isBookmarked)
                 .locations(document.getLocations().stream()
                         .map(TripDocument.Location::getName)
-                        .collect(Collectors.toList()))
+                        .collect(Collectors.toSet()))
                 .build();
     }
 }

--- a/src/main/java/com/trip/diary/dto/TripDto.java
+++ b/src/main/java/com/trip/diary/dto/TripDto.java
@@ -27,7 +27,6 @@ public class TripDto {
     private Boolean isBookmarked;
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private List<ParticipantDto> participants;
-    @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private Set<String> locations;
     @JsonInclude(JsonInclude.Include.NON_NULL)
     private Long countOfBookmark;
@@ -70,13 +69,14 @@ public class TripDto {
                 .build();
     }
 
-    public static TripDto of(TripBookmarkDto dto, boolean isBookmarked){
+    public static TripDto of(TripBookmarkDto dto, List<String> locations, boolean isBookmarked) {
         return TripDto.builder()
                 .id(dto.getTripId())
                 .title(dto.getTitle())
                 .description(dto.getDescription())
                 .isBookmarked(isBookmarked)
                 .countOfBookmark(dto.getCountOfBookmarked())
+                .locations(Set.copyOf(locations))
                 .build();
     }
 }

--- a/src/main/java/com/trip/diary/dto/TripDto.java
+++ b/src/main/java/com/trip/diary/dto/TripDto.java
@@ -27,7 +27,10 @@ public class TripDto {
     private Boolean isBookmarked;
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private List<ParticipantDto> participants;
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private Set<String> locations;
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private Long countOfBookmark;
 
     public static TripDto of(Trip trip) {
         return TripDto.builder()
@@ -64,6 +67,16 @@ public class TripDto {
                 .locations(document.getLocations().stream()
                         .map(TripDocument.Location::getName)
                         .collect(Collectors.toSet()))
+                .build();
+    }
+
+    public static TripDto of(TripBookmarkDto dto, boolean isBookmarked){
+        return TripDto.builder()
+                .id(dto.getTripId())
+                .title(dto.getTitle())
+                .description(dto.getDescription())
+                .isBookmarked(isBookmarked)
+                .countOfBookmark(dto.getCountOfBookmarked())
                 .build();
     }
 }

--- a/src/main/java/com/trip/diary/elasticsearch/repository/TripSearchRepository.java
+++ b/src/main/java/com/trip/diary/elasticsearch/repository/TripSearchRepository.java
@@ -1,6 +1,9 @@
 package com.trip.diary.elasticsearch.repository;
 
 import com.trip.diary.elasticsearch.model.TripDocument;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.elasticsearch.annotations.Query;
 import org.springframework.data.elasticsearch.repository.ElasticsearchRepository;
 import org.springframework.stereotype.Repository;
 
@@ -9,4 +12,16 @@ import java.util.Optional;
 @Repository
 public interface TripSearchRepository extends ElasticsearchRepository<TripDocument, Long> {
     Optional<TripDocument> findById(Long id);
+
+    @Query("{\"bool\": { \"should\": [ \n" +
+            "    {\"wildcard\": { \"title\": { \"value\": \"*?0*\"}}},\n" +
+            "    {\"match_phrase\": {\"description\": \"?0\"}},\n" +
+            "    {\"term\": {\"locations.name\": \"?1\"}}],\n" +
+            "    \"filter\": [{\"term\": {\"isPrivate\": false}}], \"minimum_should_match\": 1}}")
+    Page<TripDocument> findByKeyword(String keyword, String locationName, Pageable pageable);
+
+    @Query("\"bool\": { \"must\": [ \n" +
+            "    {\"term\": {\"locations.name\": \"?0\"}}],\n" +
+            "    \"filter\": [{\"term\": {\"isPrivate\": false}}]}")
+    Page<TripDocument> findByLocationsName(String locationName, Pageable pageable);
 }

--- a/src/main/java/com/trip/diary/elasticsearch/repository/TripSearchRepository.java
+++ b/src/main/java/com/trip/diary/elasticsearch/repository/TripSearchRepository.java
@@ -20,8 +20,8 @@ public interface TripSearchRepository extends ElasticsearchRepository<TripDocume
             "    \"filter\": [{\"term\": {\"isPrivate\": false}}], \"minimum_should_match\": 1}}")
     Page<TripDocument> findByKeyword(String keyword, String locationName, Pageable pageable);
 
-    @Query("\"bool\": { \"must\": [ \n" +
-            "    {\"term\": {\"locations.name\": \"?0\"}}],\n" +
-            "    \"filter\": [{\"term\": {\"isPrivate\": false}}]}")
+    @Query("{\"bool\": { \"must\": [ \n" +
+            "    {\"term\": {\"locations.name\": \"김포공항\"}}],\n" +
+            "    \"filter\": [{\"term\": {\"isPrivate\": false}}]}}")
     Page<TripDocument> findByLocationsName(String locationName, Pageable pageable);
 }

--- a/src/main/java/com/trip/diary/service/BookmarkService.java
+++ b/src/main/java/com/trip/diary/service/BookmarkService.java
@@ -46,7 +46,7 @@ public class BookmarkService {
                 .findByMember(member, PageRequest.of(page, BOOKMARK_PAGE_SIZE));
         return new SliceImpl<>(bookmarkSlice.stream()
                 .filter(bookmark -> isMemberHaveReadAuthority(bookmark.getTrip(), member))
-                .map(bookmark -> TripDto.of(bookmark.getTrip()))
+                .map(TripDto::of)
                 .collect(Collectors.toList()), bookmarkSlice.getPageable(), bookmarkSlice.hasNext());
     }
 

--- a/src/main/java/com/trip/diary/service/PostService.java
+++ b/src/main/java/com/trip/diary/service/PostService.java
@@ -48,7 +48,7 @@ public class PostService {
 
         validationMemberHaveWriteAuthority(trip, member);
 
-        Location location = getNewlyLocation(trip, form.getLocation());
+        Location location = getNewlyLocation(trip, form.getLocation().replace(" ",""));
         Post savedPost = postRepository.save(Post.of(form, location, trip, member));
         List<String> imagePaths = savePostImages(savedPost, images);
         updateLocationThumbnail(location, imagePaths.get(0));

--- a/src/main/java/com/trip/diary/service/TripSearchService.java
+++ b/src/main/java/com/trip/diary/service/TripSearchService.java
@@ -4,6 +4,7 @@ import com.trip.diary.client.ElasticSearchClient;
 import com.trip.diary.domain.model.Member;
 import com.trip.diary.domain.model.Trip;
 import com.trip.diary.domain.repository.BookmarkRepository;
+import com.trip.diary.domain.repository.TripRepositoryCustom;
 import com.trip.diary.dto.TripDto;
 import com.trip.diary.elasticsearch.model.TripDocument;
 import com.trip.diary.elasticsearch.repository.TripSearchRepository;
@@ -19,6 +20,7 @@ import static com.trip.diary.domain.constants.Constants.SEARCH_PAGE_SIZE;
 public class TripSearchService {
     private final TripSearchRepository tripSearchRepository;
     private final BookmarkRepository bookmarkRepository;
+    private final TripRepositoryCustom tripRepositoryCustom;
     private final ElasticSearchClient elasticSearchClient;
     private static final String INDEX_NAME_OF_TRIP = "trips";
 
@@ -66,5 +68,12 @@ public class TripSearchService {
                 .findByLocationsName(keyword.replace(" ", ""), PageRequest.of(page, SEARCH_PAGE_SIZE))
                 .map(tripDocument -> TripDto.of(tripDocument,
                         bookmarkRepository.existsByTrip_IdAndMember(tripDocument.getId(), member)));
+    }
+
+    public Page<TripDto> searchByKeywordOrderByBookmark(int page, String keyword, Member member) {
+        return tripRepositoryCustom
+                .findByKeywordContainsOrderByBookmark(keyword, PageRequest.of(page, SEARCH_PAGE_SIZE))
+                .map(tripBookmarkDto -> TripDto.of(tripBookmarkDto,
+                        bookmarkRepository.existsByTrip_IdAndMember(tripBookmarkDto.getTripId(), member)));
     }
 }

--- a/src/main/java/com/trip/diary/service/TripSearchService.java
+++ b/src/main/java/com/trip/diary/service/TripSearchService.java
@@ -1,16 +1,24 @@
 package com.trip.diary.service;
 
 import com.trip.diary.client.ElasticSearchClient;
+import com.trip.diary.domain.model.Member;
 import com.trip.diary.domain.model.Trip;
+import com.trip.diary.domain.repository.BookmarkRepository;
+import com.trip.diary.dto.TripDto;
 import com.trip.diary.elasticsearch.model.TripDocument;
 import com.trip.diary.elasticsearch.repository.TripSearchRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
+
+import static com.trip.diary.domain.constants.Constants.SEARCH_PAGE_SIZE;
 
 @Service
 @RequiredArgsConstructor
 public class TripSearchService {
     private final TripSearchRepository tripSearchRepository;
+    private final BookmarkRepository bookmarkRepository;
     private final ElasticSearchClient elasticSearchClient;
     private static final String INDEX_NAME_OF_TRIP = "trips";
 
@@ -43,5 +51,20 @@ public class TripSearchService {
                             elasticSearchClient.update(INDEX_NAME_OF_TRIP, tripDocument);
                         }
                 );
+    }
+
+    public Page<TripDto> search(int page, String keyword, Member member) {
+        return tripSearchRepository
+                .findByKeyword(keyword, keyword.replace(" ", ""),
+                        PageRequest.of(page, SEARCH_PAGE_SIZE))
+                .map(tripDocument -> TripDto.of(tripDocument,
+                        bookmarkRepository.existsByTrip_IdAndMember(tripDocument.getId(), member)));
+    }
+
+    public Page<TripDto> searchByLocation(int page, String keyword, Member member) {
+        return tripSearchRepository
+                .findByLocationsName(keyword.replace(" ", ""), PageRequest.of(page, SEARCH_PAGE_SIZE))
+                .map(tripDocument -> TripDto.of(tripDocument,
+                        bookmarkRepository.existsByTrip_IdAndMember(tripDocument.getId(), member)));
     }
 }

--- a/src/main/java/com/trip/diary/service/TripSearchService.java
+++ b/src/main/java/com/trip/diary/service/TripSearchService.java
@@ -4,6 +4,7 @@ import com.trip.diary.client.ElasticSearchClient;
 import com.trip.diary.domain.model.Member;
 import com.trip.diary.domain.model.Trip;
 import com.trip.diary.domain.repository.BookmarkRepository;
+import com.trip.diary.domain.repository.LocationRepositoryCustom;
 import com.trip.diary.domain.repository.TripRepositoryCustom;
 import com.trip.diary.dto.TripDto;
 import com.trip.diary.elasticsearch.model.TripDocument;
@@ -21,6 +22,7 @@ public class TripSearchService {
     private final TripSearchRepository tripSearchRepository;
     private final BookmarkRepository bookmarkRepository;
     private final TripRepositoryCustom tripRepositoryCustom;
+    private final LocationRepositoryCustom locationRepositoryCustom;
     private final ElasticSearchClient elasticSearchClient;
     private static final String INDEX_NAME_OF_TRIP = "trips";
 
@@ -74,6 +76,7 @@ public class TripSearchService {
         return tripRepositoryCustom
                 .findByKeywordContainsOrderByBookmark(keyword, PageRequest.of(page, SEARCH_PAGE_SIZE))
                 .map(tripBookmarkDto -> TripDto.of(tripBookmarkDto,
+                        locationRepositoryCustom.findLocationNameByTripId(tripBookmarkDto.getTripId()),
                         bookmarkRepository.existsByTrip_IdAndMember(tripBookmarkDto.getTripId(), member)));
     }
 }

--- a/src/test/java/com/trip/diary/controller/BookmarkControllerTest.java
+++ b/src/test/java/com/trip/diary/controller/BookmarkControllerTest.java
@@ -16,6 +16,7 @@ import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.util.List;
+import java.util.Set;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
@@ -73,7 +74,7 @@ class BookmarkControllerTest {
                                                 .nickname("냠냠")
                                                 .build()
                                 ))
-                                .locations(List.of("제주공항", "김포공항", "제주올레길"))
+                                .locations(Set.of("제주공항", "김포공항", "제주올레길"))
                                 .build()
                 )));
         //when

--- a/src/test/java/com/trip/diary/controller/TripSearchControllerTest.java
+++ b/src/test/java/com/trip/diary/controller/TripSearchControllerTest.java
@@ -1,0 +1,102 @@
+package com.trip.diary.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.trip.diary.dto.TripDto;
+import com.trip.diary.mockuser.WithMockCustomUser;
+import com.trip.diary.service.TripSearchService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+import java.util.Set;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = TripSearchController.class)
+@AutoConfigureMockMvc(addFilters = false)
+class TripSearchControllerTest {
+    @MockBean
+    private TripSearchService tripSearchService;
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    private static final String TOKEN = "Bearer token";
+
+    @Test
+    @WithMockCustomUser
+    @DisplayName("여행 기록장 검색 성공")
+    void searchTest_success() throws Exception {
+        //given
+        given(tripSearchService.search(anyInt(), anyString(), any()))
+                .willReturn(new PageImpl<>(
+                        List.of(
+                                TripDto.builder()
+                                        .id(1L)
+                                        .title("제주도가 최고")
+                                        .description("제주도 한달살기")
+                                        .locations(Set.of("한라산국립공원", "성산일출봉"))
+                                        .isBookmarked(true)
+                                        .build()
+                        )
+                ));
+        //when
+        //then
+        mockMvc.perform(get("/trips/search")
+                        .param("keyword", "제")
+                        .param("page", "0")
+                        .header("Authorization", TOKEN)
+                        .contentType(MediaType.APPLICATION_JSON)
+                )
+                .andDo(print())
+                .andExpect(status().isOk());
+
+
+    }
+
+    @Test
+    @WithMockCustomUser
+    @DisplayName("여행 기록장 로케이션 이름으로 검색 성공")
+    void searchByLocationTest_success() throws Exception {
+        //given
+        given(tripSearchService.searchByLocation(anyInt(), anyString(), any()))
+                .willReturn(new PageImpl<>(
+                        List.of(
+                                TripDto.builder()
+                                        .id(1L)
+                                        .title("제주도가 최고")
+                                        .description("제주도 한달살기")
+                                        .locations(Set.of("한라산국립공원", "성산일출봉"))
+                                        .isBookmarked(true)
+                                        .build()
+                        )
+                ));
+        //when
+        //then
+        mockMvc.perform(get("/trips/locations/search")
+                        .param("keyword", "한라산 국립공원")
+                        .param("page", "0")
+                        .header("Authorization", TOKEN)
+                        .contentType(MediaType.APPLICATION_JSON)
+                )
+                .andDo(print())
+                .andExpect(status().isOk());
+
+
+    }
+
+}

--- a/src/test/java/com/trip/diary/controller/TripSearchControllerTest.java
+++ b/src/test/java/com/trip/diary/controller/TripSearchControllerTest.java
@@ -99,4 +99,42 @@ class TripSearchControllerTest {
 
     }
 
+    @Test
+    @WithMockCustomUser
+    @DisplayName("여행 기록장 북마크 순으로 검색 성공")
+    void searchByKeywordOrderByBookmarkTest_success() throws Exception {
+        //given
+        given(tripSearchService.searchByLocation(anyInt(), anyString(), any()))
+                .willReturn(new PageImpl<>(
+                        List.of(
+                                TripDto.builder()
+                                        .id(1L)
+                                        .title("제주도가 최고")
+                                        .description("제주도 한달살기")
+                                        .isBookmarked(true)
+                                        .countOfBookmark(3L)
+                                        .build(),
+                                TripDto.builder()
+                                        .id(2L)
+                                        .title("경주가 최고")
+                                        .description("경주 한달살기")
+                                        .isBookmarked(false)
+                                        .countOfBookmark(2L)
+                                        .build()
+                        )
+                ));
+        //when
+        //then
+        mockMvc.perform(get("/trips/bookmarks/search")
+                        .param("keyword", "한달살기")
+                        .param("page", "0")
+                        .header("Authorization", TOKEN)
+                        .contentType(MediaType.APPLICATION_JSON)
+                )
+                .andDo(print())
+                .andExpect(status().isOk());
+
+
+    }
+
 }

--- a/src/test/java/com/trip/diary/service/PostServiceTest.java
+++ b/src/test/java/com/trip/diary/service/PostServiceTest.java
@@ -239,8 +239,8 @@ class PostServiceTest {
         //then
         verify(postRepository, times(1)).save(postCaptor.capture());
         verify(locationRepository, times(1)).save(locationCaptor.capture());
-        assertEquals("아베베 베이커리", postCaptor.getValue().getLocation().getName());
-        assertEquals("아베베 베이커리", locationCaptor.getValue().getName());
+        assertEquals("아베베베이커리", postCaptor.getValue().getLocation().getName());
+        assertEquals("아베베베이커리", locationCaptor.getValue().getName());
         assertEquals("/post/1.jpg", locationCaptor.getValue().getThumbnailPath());
     }
 


### PR DESCRIPTION
## What is this PR? 🔎
여행 기록장을 키워드를 통해 검색하는 기능입니다.
키워드를 입력하면, 해당 키워드가 타이틀에 포함되거나 설명에 구문으로 들어가 있거나, 로케이션이 정확히 일치하는 경우 반환합니다.
여행 기록장의 로케이션만 대상으로 검색하는 기능과, 
북마크 순으로 특정 키워드를 제목이나 설명에 포함한 여행 기록장을 검색하는 기능도 함께 구현했습니다.
 
## Changes ✅
- 여행 기록장에 대한 검색 기능
- 여행 기록장 로케이션만 대상으로 검색 기능
- 여행 기록장을 북마크 순으로 검색하는 기능

## To Reviewers 🙇‍♀️ 

제목, 설명, 로케이션을 대상으로 검색하는 기능에 대한 `elastic search` 쿼리
```
{"bool": { "should": [ 
    {"wildcard": { "title": { "value": "*송송*"}}},
    {"match_phrase": {"description": "메롱"}},
    {"term": {"locations.name": "정발산"}}],
    "filter": [{"term": {"isPrivate": false}}], "minimum_should_match": 1}}
```
로케이션을 대상으로 여행 일기장을 검색하는 기능에 대한 `elastic search` 쿼리
```
{"bool": { "must": [ 
    {"term": {"locations.name": "김포공항"}}],
    "filter": [{"term": {"isPrivate": false}}]}}
```
